### PR TITLE
Green Checkmark

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -134,7 +134,7 @@
             };
           };
         };
-        mkUnsignedTest = { name, path }: mkSecureBootTest {
+        mkUnsignedTest = { name, path, machine ? {} }: mkSecureBootTest {
           inherit name;
           testScript = ''
             import json
@@ -174,6 +174,20 @@
             assert "Secure Boot: enabled (user)" in machine.succeed("bootctl status")
           '';
           };
+
+          lanzaboote-boot-lockdown = mkSecureBootTest {
+            name = "system-boots-with-lockdown-enabled";
+
+            machine = { ... }: {
+              boot.lanzaboote.lockdown = true;
+            };
+
+            testScript = ''
+              machine.start()
+              assert "Secure Boot: enabled (user)" in machine.succeed("bootctl status")
+            '';
+          };
+
           # So, this is the responsibility of the lanzatool install
           # to run the append-initrd-secret script
           # This test assert that lanzatool still do the right thing

--- a/nix/lanzaboote.nix
+++ b/nix/lanzaboote.nix
@@ -1,4 +1,4 @@
-{ lib, config, pkgs, ... }: 
+{ lib, config, pkgs, ... }:
 with lib;
 let
   cfg = config.boot.lanzaboote;
@@ -10,6 +10,11 @@ in
   options.boot.lanzaboote = {
     enable = mkEnableOption "Enable the LANZABOOTE";
     enrollKeys = mkEnableOption "Automatic enrollment of the keys using sbctl";
+
+    # To get that elusive green checkmark from GNOME Device Security /
+    # fwupdtool security.
+    lockdown = mkEnableOption "Security Lockdown";
+
     pkiBundle = mkOption {
       type = types.nullOr types.path;
       default = null;
@@ -44,7 +49,7 @@ in
           cp -r ${cfg.pkiBundle}/* /tmp/pki
           ${sbctlWithPki}/bin/sbctl enroll-keys --yes-this-might-brick-my-machine
         ''}
-  
+
         ${cfg.package}/bin/lanzatool install \
           --pki-bundle ${cfg.pkiBundle} \
           --public-key ${cfg.publicKeyFile} \
@@ -53,5 +58,24 @@ in
           /nix/var/nix/profiles/system-*-link
       '';
     };
+
+    boot.kernelParams = mkIf cfg.lockdown [ "mem_encrypt=on" ];
+
+    boot.kernelPatches = mkIf cfg.lockdown [
+      {
+        # The thinklmi driver is violating the sysfs spec and fwupd
+        # really wants its 'type' field in the firmware attributes.
+        name = "think-lmi-fwupd-compat";
+        patch = ./patches/linux/0001-platform-x86-think-lmi-expose-type-attribute.patch;
+
+        # TODO Userspace must still enable lockdown via /sys/kernel/security/lockdown or via command line.
+        extraConfig = ''
+          AMD_MEM_ENCRYPT y
+
+          SECURITY_LOCKDOWN_LSM y
+          SECURITY_LOCKDOWN_LSM_EARLY y
+        '';
+      }
+    ];
   };
 }

--- a/nix/patches/linux/0001-platform-x86-think-lmi-expose-type-attribute.patch
+++ b/nix/patches/linux/0001-platform-x86-think-lmi-expose-type-attribute.patch
@@ -1,0 +1,62 @@
+From a0691689e401906a30d95781e7e6cb1b8ea4077e Mon Sep 17 00:00:00 2001
+From: Julian Stecklina <js@alien8.de>
+Date: Fri, 25 Nov 2022 13:27:27 +0100
+Subject: [PATCH] platform/x86: think-lmi: expose 'type' attribute
+
+think-lmi currently doesn't adhere to sysfs layout for
+firmware-attributes. It doesn't expose a 'type' file. As we already
+expose 'possible_values', we need to set the type to "enumeration".
+
+This fixes the following fwupd error message:
+
+   sudo fwupdtool security
+[sudo] password for julian:
+Loading                 [*************************              ]
+12:27:57:0662 FuBiosSettings       KERNEL BUG: 'type' attribute not exported: (failed to load type: Failed to open file /sys/class/firmware-attributes/thinklmi/attributes/SecureBoot/type: No such file or directory)
+Loading                 [-                                      ]
+
+Not enough data was provided to make an HSI calculation.
+  https://fwupd.github.io/hsi.html#not-enough-info
+To ignore this warning, use --force
+
+Signed-off-by: Julian Stecklina <julian.stecklina@cyberus-technology.de>
+---
+ drivers/platform/x86/think-lmi.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/platform/x86/think-lmi.c b/drivers/platform/x86/think-lmi.c
+index a01a92769c1a..eb6dc01a449e 100644
+--- a/drivers/platform/x86/think-lmi.c
++++ b/drivers/platform/x86/think-lmi.c
+@@ -917,6 +917,12 @@ static ssize_t display_name_show(struct kobject *kobj, struct kobj_attribute *at
+ 	return sysfs_emit(buf, "%s\n", setting->display_name);
+ }
+ 
++static ssize_t type_show(struct kobject *kobj, struct kobj_attribute *attr,
++		char *buf)
++{
++	return sysfs_emit(buf, "enumeration\n");
++}
++
+ static ssize_t current_value_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf)
+ {
+ 	struct tlmi_attr_setting *setting = to_tlmi_attr_setting(kobj);
+@@ -1034,12 +1040,15 @@ static struct kobj_attribute attr_displ_name = __ATTR_RO(display_name);
+ 
+ static struct kobj_attribute attr_possible_values = __ATTR_RO(possible_values);
+ 
++static struct kobj_attribute attr_type = __ATTR_RO(type);
++
+ static struct kobj_attribute attr_current_val = __ATTR_RW_MODE(current_value, 0600);
+ 
+ static struct attribute *tlmi_attrs[] = {
+ 	&attr_displ_name.attr,
+ 	&attr_current_val.attr,
+ 	&attr_possible_values.attr,
++	&attr_type.attr,
+ 	NULL
+ };
+ 
+-- 
+2.38.1
+


### PR DESCRIPTION
This PR works towards the green checkmark in GNOME Device Security. For that we need to:

- [ ] Placate `fwupdtool security`
  - [ ] Make thinklmi export a sane sysfs (see Linux patch)
    - The current patch is wrong. See discussion in: https://bugzilla.kernel.org/show_bug.cgi?id=216460 
  - [ ] "Unsupported CPU" on AMD? https://github.com/fwupd/fwupd/issues/5284
- [ ] Enable [kernel lockdown](https://mjg59.dreamwidth.org/50577.html)
  - [x] Enable the kernel options
  - [ ] Enable lockdown on boot
