### PR TITLE
Drop Naersk and Enable Clippy for lanzaboote

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1668993159,
-        "narHash": "sha256-9BVTtPFrHRh0HbeEm2bmXsoIWRj1tKM6Nvfl7VMK/X8=",
+        "lastModified": 1669605882,
+        "narHash": "sha256-TiQtL5sUI5rp28S63v+VX25qNjcrc8Xeu+shf3g7Tj4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "c61d98aaea5667607a36bafe5a6fa87fe5bb2c7e",
+        "rev": "24591d5f8cc979f7b243b88a2d39da09976970ad",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669207345,
-        "narHash": "sha256-KwfRW0f70Y19EkbB6D9wy7AoYqCYPuIL/2taiJPvuxg=",
+        "lastModified": 1669535121,
+        "narHash": "sha256-koZLM7oWVGrjyHnYDo7/w5qlmUn9UZUKSFNfmIjueE8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ea5616c21dd186129f90a86c66352359a45cb07",
+        "rev": "b45ec953794bb07922f0468152ad1ebaf8a084b3",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1669207345,
-        "narHash": "sha256-KwfRW0f70Y19EkbB6D9wy7AoYqCYPuIL/2taiJPvuxg=",
+        "lastModified": 1669535121,
+        "narHash": "sha256-koZLM7oWVGrjyHnYDo7/w5qlmUn9UZUKSFNfmIjueE8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ea5616c21dd186129f90a86c66352359a45cb07",
+        "rev": "b45ec953794bb07922f0468152ad1ebaf8a084b3",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1669257187,
-        "narHash": "sha256-NURtNyepbHLrJs2kwsQ9u2SUKhuGU1T9mPkXasG9hpk=",
+        "lastModified": 1669602829,
+        "narHash": "sha256-I3LBvBiVui4Rf0iQvTqUIgBovaLDzpOzsoNEzCsDowg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "018df6d3f900fc53d567045bd86208f5c00d8956",
+        "rev": "b9da8e68a08707115be750c0cf7ade33f49d8ec4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -69,24 +69,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1662220400,
-        "narHash": "sha256-9o2OGQqu4xyLZP9K6kNe1pTHnyPz0Wr3raGYnr9AIgY=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "6944160c19cb591eb85bbf9b2f2768a935623ed3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1669535121,
@@ -97,8 +79,10 @@
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-test": {
@@ -119,22 +103,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1669535121,
-        "narHash": "sha256-koZLM7oWVGrjyHnYDo7/w5qlmUn9UZUKSFNfmIjueE8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b45ec953794bb07922f0468152ad1ebaf8a084b3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1665296151,
         "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
         "owner": "NixOS",
@@ -152,8 +120,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-test": "nixpkgs-test",
         "rust-overlay": "rust-overlay_2"
       }
@@ -186,7 +153,7 @@
     "rust-overlay_2": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1669602829,

--- a/nix/uefi-run.nix
+++ b/nix/uefi-run.nix
@@ -1,5 +1,5 @@
-{ fetchFromGitHub, naersk, makeWrapper, OVMF, qemu }:
-naersk.buildPackage {
+{ fetchFromGitHub, craneLib, makeWrapper, OVMF, qemu }:
+craneLib.buildPackage {
   src = fetchFromGitHub {
     owner = "Richard-W";
     repo = "uefi-run";
@@ -11,7 +11,11 @@ naersk.buildPackage {
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''
-    wrapProgram "$out/bin/uefi-run" \
-      --add-flags '--bios-path ${OVMF.fd}/FV/OVMF.fd --qemu-path ${qemu}/bin/qemu-system-x86_64'
+    # The hook runs for the dependency-only derivation where the binary is not
+    # produced. We need to skip it there.
+    if [ -f $out/bin/uefi-run ]; then
+      wrapProgram "$out/bin/uefi-run" \
+        --add-flags '--bios-path ${OVMF.fd}/FV/OVMF.fd --qemu-path ${qemu}/bin/qemu-system-x86_64'
+    fi
   '';
 }

--- a/rust/lanzaboote/src/linux_loader.rs
+++ b/rust/lanzaboote/src/linux_loader.rs
@@ -147,16 +147,16 @@ fn initrd_location(initrd_efi: &mut RegularFile) -> Result<Range<usize>> {
         .sections
         .iter()
         .find(|s| s.name().unwrap() == ".initrd")
-        .and_then(|s| {
+        .map(|s| {
             let section_start: usize = s.pointer_to_raw_data.try_into().unwrap();
             let section_size: usize = s.size_of_raw_data.try_into().unwrap();
 
-            Some(Range {
+            Range {
                 start: section_start,
                 end: section_start + section_size,
-            })
+            }
         })
-        .ok_or(Status::END_OF_FILE.into())
+        .ok_or_else(|| Status::END_OF_FILE.into())
 }
 
 /// Check the signature of the initrd.

--- a/rust/lanzaboote/src/pe_section.rs
+++ b/rust/lanzaboote/src/pe_section.rs
@@ -1,3 +1,9 @@
+// Clippy doesn't like the lifetimes, but rustc wants them. 🤷
+#![allow(clippy::needless_lifetimes)]
+// Clippy doesn't understand that we exit with ? from the closure in
+// and_then below and this can't be expressed with map.
+#![allow(clippy::bind_instead_of_map)]
+
 use alloc::{borrow::ToOwned, string::String};
 
 /// Extracts the data of a section of a PE file.
@@ -20,6 +26,5 @@ pub fn pe_section<'a>(file_data: &'a [u8], section_name: &str) -> Option<&'a [u8
 
 /// Extracts the data of a section of a PE file and returns it as a string.
 pub fn pe_section_as_string<'a>(file_data: &'a [u8], section_name: &str) -> Option<String> {
-    pe_section(file_data, section_name)
-        .and_then(|data| Some(core::str::from_utf8(data).unwrap().to_owned()))
+    pe_section(file_data, section_name).map(|data| core::str::from_utf8(data).unwrap().to_owned())
 }


### PR DESCRIPTION
This PR:

- fixes Clippy issues in lanzaboote (where possible),
- switches the build of all Rust components to Crane (Thanks to https://github.com/ipetkov/crane/pull/174 :tada:)
- enables clippy for lanzaboote in `nix flake check`
- drops the Naersk dependency

This PR will have some trivial merge conflicts with #21. But as they are easy to resolve, we can merge these PRs in any order.