### PR TITLE
deduplicate flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,15 @@
     "crane": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": [
+          "rust-overlay"
+        ]
       },
       "locked": {
         "lastModified": 1669605882,
@@ -54,21 +58,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1669535121,
@@ -101,59 +90,23 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1665296151,
-        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "crane": "crane",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-test": "nixpkgs-test",
-        "rust-overlay": "rust-overlay_2"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
         "flake-utils": [
-          "crane",
           "flake-utils"
         ],
         "nixpkgs": [
-          "crane",
           "nixpkgs"
         ]
-      },
-      "locked": {
-        "lastModified": 1667487142,
-        "narHash": "sha256-bVuzLs1ZVggJAbJmEDVO9G6p8BH3HRaolK70KXvnWnU=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1669602829,

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
 
       nixosModules.lanzaboote = { pkgs, lib, ... }: {
         imports = [ ./nix/lanzaboote.nix ];
-        boot.lanzaboote.package = lib.mkDefault self.packages.${pkgs.system}.lanzaboote;
+        boot.lanzaboote.package = lib.mkDefault self.packages.${pkgs.system}.lanzatool;
       };
 
       packages.x86_64-linux = {

--- a/flake.nix
+++ b/flake.nix
@@ -7,13 +7,21 @@
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
+      inputs.flake-utils.follows = "flake-utils";
     };
 
     nixpkgs-test.url = "github:RaitoBezarius/nixpkgs/experimental-secureboot";
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, crane, nixpkgs-test, rust-overlay }:
+  outputs = { self, nixpkgs, crane, nixpkgs-test, rust-overlay, ... }:
     let
       pkgs = import nixpkgs {
         system = "x86_64-linux";

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,10 @@
         inherit lanzatool;
       };
 
-      nixosModules.lanzaboote = import ./nix/lanzaboote.nix;
+      nixosModules.lanzaboote = { pkgs, lib, ... }: {
+        imports = [ ./nix/lanzaboote.nix ];
+        boot.lanzaboote.package = lib.mkDefault self.packages.${pkgs.system}.lanzaboote;
+      };
 
       packages.x86_64-linux = {
         inherit initrd-stub lanzaboote lanzatool;

--- a/nix/lanzaboote.nix
+++ b/nix/lanzaboote.nix
@@ -12,17 +12,16 @@ in
     enrollKeys = mkEnableOption "Automatic enrollment of the keys using sbctl";
     pkiBundle = mkOption {
       type = types.nullOr types.path;
-      default = null;
       description = "PKI bundle containg db, PK, KEK";
     };
     publicKeyFile = mkOption {
       type = types.path;
-      default = if cfg.pkiBundle != null then "${cfg.pkiBundle}/keys/db/db.pem" else null;
+      default = "${cfg.pkiBundle}/keys/db/db.pem";
       description = "Public key to sign your boot files";
     };
     privateKeyFile = mkOption {
       type = types.path;
-      default = if cfg.pkiBundle != null then "${cfg.pkiBundle}/keys/db/db.key" else null;
+      default = "${cfg.pkiBundle}/keys/db/db.key";
       description = "Private key to sign your boot files";
     };
     package = mkOption {


### PR DESCRIPTION
without this users end up with multiple copies of nixpkgs, which cannot be overriden from the outside (follows only works on 1 level).