### PR TITLE
nixos/lanzaboote: support unsigned generation policies

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -8,8 +8,22 @@ let
 in
 {
   options.boot.lanzaboote = {
-    enable = mkEnableOption "Enable the LANZABOOTE";
-    enrollKeys = mkEnableOption "Automatic enrollment of the keys using sbctl";
+    enable = mkEnableOption "LANZABOOTE";
+    enrollKeys = mkEnableOption "automatic enrollment of the keys using sbctl, DO NOT USE IF YOU DO NOT UNDERSTAND HOW IT WORKS, IT WILL BRICK YOUR MACHINE.";
+    unsignedGenerationsPolicy = mkOption {
+      type = types.enum [ "resign" "ignore" "resign-last-only" ];
+      default = "ignore";
+      description = ''
+        When introducing SecureBoot in your system, you will most likely have old generations
+        which are unsigned and will cease to boot.
+
+        Depending on your threat model, you may want to:
+
+        - resign all of them, ignoring all possibility of existing vulnerabilities in them
+        - resign only the last generation, reducing your risk to the very last one, useful if you want to have a known configuration with limited exposure
+        - ignore all of them, rendering your rollback feature unusable until SecureBoot is disabled or new generations are introduced
+      '';
+    };
     pkiBundle = mkOption {
       type = types.nullOr types.path;
       description = "PKI bundle containg db, PK, KEK";
@@ -49,6 +63,7 @@ in
         ${cfg.package}/bin/lanzatool install \
           --public-key ${cfg.publicKeyFile} \
           --private-key ${cfg.privateKeyFile} \
+          --unsigned-generations-policy ${cfg.unsignedGenerationsPolicy} \
           ${config.boot.loader.efi.efiSysMountPoint} \
           /nix/var/nix/profiles/system-*-link
       '';

--- a/rust/lanzatool/src/cli.rs
+++ b/rust/lanzatool/src/cli.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
+use crate::policy::LanzabootPolicy;
 use crate::install;
 use crate::signature::KeyPair;
 
@@ -26,6 +27,10 @@ struct InstallCommand {
     /// sbsign Private Key
     #[arg(long)]
     private_key: PathBuf,
+
+    /// unsigned generations policy
+    #[arg(long)]
+    unsigned_generations_policy: String,
 
     /// EFI system partition mountpoint (e.g. efiSysMountPoint)
     esp: PathBuf,
@@ -59,6 +64,9 @@ fn install(args: InstallCommand) -> Result<()> {
         key_pair,
         args.esp,
         args.generations,
+        LanzabootPolicy {
+            unsigned_generations_policy: args.unsigned_generations_policy.try_into()?
+        }
     )
     .install()
 }

--- a/rust/lanzatool/src/install.rs
+++ b/rust/lanzatool/src/install.rs
@@ -10,6 +10,7 @@ use tempfile::tempdir;
 use crate::esp::EspPaths;
 use crate::generation::Generation;
 use crate::pe;
+use crate::policy::LanzabootPolicy;
 use crate::signature::KeyPair;
 
 pub struct Installer {
@@ -17,6 +18,7 @@ pub struct Installer {
     key_pair: KeyPair,
     esp: PathBuf,
     generations: Vec<PathBuf>,
+    policy: LanzabootPolicy
 }
 
 impl Installer {
@@ -25,12 +27,14 @@ impl Installer {
         key_pair: KeyPair,
         esp: PathBuf,
         generations: Vec<PathBuf>,
+        policy: LanzabootPolicy
     ) -> Self {
         Self {
             lanzaboote_stub,
             key_pair,
             esp,
             generations,
+            policy
         }
     }
 

--- a/rust/lanzatool/src/install.rs
+++ b/rust/lanzatool/src/install.rs
@@ -36,10 +36,16 @@ impl Installer {
 
     pub fn install(&self) -> Result<()> {
         for toplevel in &self.generations {
-            let generation = Generation::from_toplevel(toplevel).with_context(|| {
+            let generation_result = Generation::from_toplevel(toplevel).with_context(|| {
                 format!("Failed to build generation from toplevel: {toplevel:?}")
-            })?;
+            });
 
+            if let Err(e) = generation_result {
+                println!("Malformed generation: {:?}", e);
+                continue;
+            }
+
+            let generation = generation_result.unwrap();
             println!("Installing generation {generation}");
 
             self.install_generation(&generation)

--- a/rust/lanzatool/src/main.rs
+++ b/rust/lanzatool/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod esp;
 mod generation;
+mod policy;
 mod install;
 mod pe;
 mod signature;

--- a/rust/lanzatool/src/policy.rs
+++ b/rust/lanzatool/src/policy.rs
@@ -1,0 +1,34 @@
+use std::fmt::Display;
+
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub enum UnsignedGenerationsPolicy {
+    ResignEverything,
+    ResignPreviousGenerationOnly,
+    IgnoreEverything
+}
+
+pub struct LanzabootPolicy {
+    unsigned_generations_policy: UnsignedGenerationsPolicy,
+}
+
+impl Display for UnsignedGenerationsPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ResignEverything => write!(f, "resign everything policy"),
+            Self::ResignPreviousGenerationOnly => write!(f, "resign only the previous generation policy"),
+            Self::IgnoreEverything => write!(f, "ignore everything policy"),
+        }
+    }
+}
+
+impl TryFrom<String> for UnsignedGenerationsPolicy {
+    fn try_from(value: String) {
+        match value.lower() {
+            "resign" => Ok(Self::ResignEverything),
+            "resign-last-only" => Ok(Self::ResignPreviousGenerationOnly),
+            "ignore" => Ok(Self::IgnoreEverything),
+            _ => Err("expected `resign`, `resign-last-only` or `ignore` for unsigned generations policy")
+        }
+    }
+}


### PR DESCRIPTION
This is open for comments, implementation will follow once I have a bit of time.

So we discussed this during the sprint and never got around it properly.

A NixOS user is going to go through these steps in his life:

- disabled SecureBoot
- enabled SecureBoot
- disabled SecureBoot
- enabled SecureBoot

etc.

NixOS has this neat feature about rollbacks, and SecureBoot interferes with it by breaking the unsigned generations.

**Note that a generation signed with the wrong key is considered as an unsigned generation here.**

To offer maximum flexibility, I want to offer three policies:

- `resign`: ignore all risks and resign everything, this is particularly dangerous but fine on a development machine, testing machine and people who do not believe they are going to be targeted by Bad Actors™, of course, we do not advise this level of policy for normal operations.
- `resign-last-only`: resign only the LAST (or current) generation. Assuming a rootkit infecting everything that looks like a kernel, initrd, etc., this will not fix the situation. But, if you build a **new generation** that you **inspect** and **trust**, this can alleviate the problem, then you can have an unsigned generation you can go back in case lanzaboote is broken. We recommend this policy for normal operations.
- `ignore`: break all old generations (until SB is disabled), this is recommended for more serious operations, combined with appropriate way to trust your derivations at runtime.
