### PR TITLE
lanzatool: ignore malformed generations

### DIFF
--- a/rust/lanzatool/src/install.rs
+++ b/rust/lanzatool/src/install.rs
@@ -36,10 +36,18 @@ impl Installer {
 
     pub fn install(&self) -> Result<()> {
         for toplevel in &self.generations {
-            let generation = Generation::from_toplevel(toplevel).with_context(|| {
+            let generation_result = Generation::from_toplevel(toplevel).with_context(|| {
                 format!("Failed to build generation from toplevel: {toplevel:?}")
-            })?;
+            });
 
+            let generation = match generation_result {
+                Ok(generation) => generation,
+                Err(e) => {
+                    println!("Malformed generation: {:?}", e);
+                    continue;
+                }
+            };
+            
             println!("Installing generation {generation}");
 
             self.install_generation(&generation)


### PR DESCRIPTION
This makes lanzaboote usable on master.