### PR TITLE
Move lanzatool to inputsFrom in devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,6 @@
       devShells.x86_64-linux.default = pkgs.mkShell {
         packages = [
           uefi-run
-          lanzatool
           pkgs.openssl
           (pkgs.sbctl.override {
             databasePath = "pki";
@@ -133,6 +132,7 @@
 
         inputsFrom = [
           lanzaboote
+          lanzatool
         ];
       };
 


### PR DESCRIPTION
When lanzatool is in the packages attr of the devShell, any compliation error in lanzatool means direnv cannot load the environment anymore. Then LSP support in your editor and even cargo in your shell is missing.