### PR TITLE
Switch to flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -59,6 +59,24 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1673047662,
+        "narHash": "sha256-dXYxH/0Ea5oQSkGAWWNy7HzmFutguycDGn2dt6lTYRQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "aa1f6ca773b6e740037ebfb35f7010e0c3960638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -90,6 +108,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1672350804,
+        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-test": {
       "locked": {
         "lastModified": 1671812130,
@@ -110,6 +146,7 @@
       "inputs": {
         "crane": "crane",
         "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-test": "nixpkgs-test",

--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670900067,
-        "narHash": "sha256-VXVa+KBfukhmWizaiGiHRVX/fuk66P8dgSFfkVN4/MY=",
+        "lastModified": 1673056065,
+        "narHash": "sha256-a68tMDTDqdAauxq377ALl4Uwm6oh9MeoY2WbTYRWZoo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "59b31b41a589c0a65e4a1f86b0e5eac68081468b",
+        "rev": "0144134311767fcee80213321f079a8ffa0b9cc1",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671755972,
-        "narHash": "sha256-X977apvpqBqqRf2XBNorfunZmQNn3cQYGEnQE4L90Fo=",
+        "lastModified": 1673039641,
+        "narHash": "sha256-Bc9FVhyLxp2mX2SXr0N4Fj4St7o4yaYEXpd12etSNBY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8ee153b1717dca9c6aa38d5cf198329480d5b41",
+        "rev": "d9f73e41fd3c8e85b266bdb91cb7535600010798",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671243596,
-        "narHash": "sha256-vQ1q6uwx2gKsHbQVhkq17nT8HwUmRbIG8cJVFafNb5s=",
+        "lastModified": 1673058265,
+        "narHash": "sha256-FFigGHIO9BQeIIKjH5dcpB+ey5CSgfy47wHPGeOhCps=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "905db21103d646ddc1eb81920e05180e6e2b6734",
+        "rev": "802ff3314663ec7114f29a6e8b200dfc892023f8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,12 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
     nixpkgs-test.url = "github:RaitoBezarius/nixpkgs/simplified-qemu-boot-disks";
 
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    # We only have this input to pass it to other dependencies and
+    # avoid having mulitple versions in our dependencies.
+    flake-utils.url = "github:numtide/flake-utils";
+
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -22,81 +28,81 @@
       url = "github:edolstra/flake-compat";
       flake = false;
     };
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-test, crane, rust-overlay, ... }:
-    let
-      pkgs = import nixpkgs {
-        system = "x86_64-linux";
-        overlays = [
-          rust-overlay.overlays.default
-        ];
-      };
-
-      testPkgs = import nixpkgs-test { system = "x86_64-linux"; };
-
-      inherit (pkgs) lib;
-
-      rust-nightly = pkgs.rust-bin.fromRustupToolchainFile ./rust/lanzaboote/rust-toolchain.toml;
-      craneLib = crane.lib.x86_64-linux.overrideToolchain rust-nightly;
-
-      uefi-run = pkgs.callPackage ./nix/packages/uefi-run.nix {
-        inherit craneLib;
-      };
-
-      # Build attributes for a Rust application.
-      buildRustApp =
-        { src
-        , target ? null
-        , doCheck ? true
-        , extraArgs ? { }
-        }:
-        let
-          commonArgs = {
-            inherit src;
-            CARGO_BUILD_TARGET = target;
-            inherit doCheck;
-          } // extraArgs;
-
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-        in
-        {
-          package = craneLib.buildPackage (commonArgs // {
-            inherit cargoArtifacts;
-          });
-
-          clippy = craneLib.cargoClippy (commonArgs // {
-            inherit cargoArtifacts;
-            cargoClippyExtraArgs = "-- --deny warnings";
-          });
-        };
-
-      lanzabooteCrane = buildRustApp {
-        src = craneLib.cleanCargoSource ./rust/lanzaboote;
-        target = "x86_64-unknown-uefi";
-        doCheck = false;
-      };
-
-      lanzaboote = lanzabooteCrane.package;
-
-      lanzatoolCrane = buildRustApp {
-        src = ./rust/lanzatool;
-        extraArgs = {
-          TEST_SYSTEMD = pkgs.systemd;
-          checkInputs = with pkgs; [
-            binutils-unwrapped
-            sbsigntool
+  outputs = inputs@{ self, nixpkgs, nixpkgs-test, crane, rust-overlay, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = let
+        pkgs = import nixpkgs {
+          system = "x86_64-linux";
+          overlays = [
+            rust-overlay.overlays.default
           ];
         };
-      };
 
-      lanzatool-unwrapped = lanzatoolCrane.package;
+        testPkgs = import nixpkgs-test { system = "x86_64-linux"; };
 
-      lanzatool = pkgs.runCommand "lanzatool"
-        {
-          nativeBuildInputs = [ pkgs.makeWrapper ];
-        } ''
+        inherit (pkgs) lib;
+
+        rust-nightly = pkgs.rust-bin.fromRustupToolchainFile ./rust/lanzaboote/rust-toolchain.toml;
+        craneLib = crane.lib.x86_64-linux.overrideToolchain rust-nightly;
+
+        uefi-run = pkgs.callPackage ./nix/packages/uefi-run.nix {
+          inherit craneLib;
+        };
+
+        # Build attributes for a Rust application.
+        buildRustApp =
+          { src
+          , target ? null
+          , doCheck ? true
+          , extraArgs ? { }
+          }:
+          let
+            commonArgs = {
+              inherit src;
+              CARGO_BUILD_TARGET = target;
+              inherit doCheck;
+            } // extraArgs;
+
+            cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          in
+            {
+              package = craneLib.buildPackage (commonArgs // {
+                inherit cargoArtifacts;
+              });
+
+              clippy = craneLib.cargoClippy (commonArgs // {
+                inherit cargoArtifacts;
+                cargoClippyExtraArgs = "-- --deny warnings";
+              });
+            };
+
+        lanzabooteCrane = buildRustApp {
+          src = craneLib.cleanCargoSource ./rust/lanzaboote;
+          target = "x86_64-unknown-uefi";
+          doCheck = false;
+        };
+
+        lanzaboote = lanzabooteCrane.package;
+
+        lanzatoolCrane = buildRustApp {
+          src = ./rust/lanzatool;
+          extraArgs = {
+            TEST_SYSTEMD = pkgs.systemd;
+            checkInputs = with pkgs; [
+              binutils-unwrapped
+              sbsigntool
+            ];
+          };
+        };
+
+        lanzatool-unwrapped = lanzatoolCrane.package;
+
+        lanzatool = pkgs.runCommand "lanzatool"
+          {
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+          } ''
         mkdir -p $out/bin
 
         # Clean PATH to only contain what we need to do objcopy. Also
@@ -106,51 +112,60 @@
           --set RUST_BACKTRACE full \
           --set LANZABOOTE_STUB ${lanzaboote}/bin/lanzaboote.efi
       '';
-    in
-    {
-      overlays.default = final: prev: {
-        inherit lanzatool;
+      in
+        {
+          overlays.default = final: prev: {
+            inherit lanzatool;
+          };
+
+          nixosModules.lanzaboote = { pkgs, lib, ... }: {
+            imports = [ ./nix/modules/lanzaboote.nix ];
+            boot.lanzaboote.package = lib.mkDefault self.packages.${pkgs.system}.lanzatool;
+          };
+
+          packages.x86_64-linux = {
+            inherit lanzaboote lanzatool;
+            default = lanzatool;
+          };
+
+          devShells.x86_64-linux.default = pkgs.mkShell {
+            packages = [
+              uefi-run
+              pkgs.openssl
+              (pkgs.sbctl.override {
+                databasePath = "pki";
+              })
+              pkgs.sbsigntool
+              pkgs.efitools
+              pkgs.python39Packages.ovmfvartool
+              pkgs.qemu
+              pkgs.nixpkgs-fmt
+              pkgs.statix
+            ];
+
+            inputsFrom = [
+              lanzaboote
+              lanzatool
+            ];
+
+            TEST_SYSTEMD = pkgs.systemd;
+          };
+
+          checks.x86_64-linux = {
+            lanzatool-clippy = lanzatoolCrane.clippy;
+            lanzaboote-clippy = lanzabooteCrane.clippy;
+          } // (import ./nix/tests/lanzaboote.nix {
+            inherit pkgs testPkgs;
+            lanzabooteModule = self.nixosModules.lanzaboote;
+          });
+        };
+
+      systems = [
+        "x86_64-linux"
+      ];
+
+      perSystem = { config, ... }: {
+        # Nothing here yet.
       };
-
-      nixosModules.lanzaboote = { pkgs, lib, ... }: {
-        imports = [ ./nix/modules/lanzaboote.nix ];
-        boot.lanzaboote.package = lib.mkDefault self.packages.${pkgs.system}.lanzatool;
-      };
-
-      packages.x86_64-linux = {
-        inherit lanzaboote lanzatool;
-        default = lanzatool;
-      };
-
-      devShells.x86_64-linux.default = pkgs.mkShell {
-        packages = [
-          uefi-run
-          pkgs.openssl
-          (pkgs.sbctl.override {
-            databasePath = "pki";
-          })
-          pkgs.sbsigntool
-          pkgs.efitools
-          pkgs.python39Packages.ovmfvartool
-          pkgs.qemu
-          pkgs.nixpkgs-fmt
-          pkgs.statix
-        ];
-
-        inputsFrom = [
-          lanzaboote
-          lanzatool
-        ];
-
-        TEST_SYSTEMD = pkgs.systemd;
-      };
-
-      checks.x86_64-linux = {
-        lanzatool-clippy = lanzatoolCrane.clippy;
-        lanzaboote-clippy = lanzabooteCrane.clippy;
-      } // (import ./nix/tests/lanzaboote.nix {
-        inherit pkgs testPkgs;
-        lanzabooteModule = self.nixosModules.lanzaboote;
-      });
     };
 }


### PR DESCRIPTION
In order to make multiple architectures and goodies like [pre-commit](https://github.com/cachix/pre-commit-hooks.nix) easier, I've switched out flakes.nix to using [flake-parts](https://flake.parts).

This also removes some hacks in getting the right `lanzatool` into our module. There should be no user-visible changes.

While I was here, I also updated our inputs.

Fixes #45.