### PR TITLE
Enable Typo Checks

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -126,7 +126,7 @@ nixosConfigurations = {
           pkgs.sbctl
         ];
 
-        # Lanzaboote currently replaces the sytemd-boot module.
+        # Lanzaboote currently replaces the systemd-boot module.
 		# This setting is usually set to true in configuration.nix
 		# generated at installation time. So we force it to false
 		# for now.

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     };
 
     # We only have this input to pass it to other dependencies and
-    # avoid having mulitple versions in our dependencies.
+    # avoid having multiple versions in our dependencies.
     flake-utils.url = "github:numtide/flake-utils";
 
     crane = {

--- a/flake.nix
+++ b/flake.nix
@@ -166,6 +166,7 @@
 
             settings.hooks = {
               nixpkgs-fmt.enable = true;
+              typos.enable = true;
             };
           };
 

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -25,7 +25,7 @@ in
     };
     pkiBundle = mkOption {
       type = types.nullOr types.path;
-      description = "PKI bundle containg db, PK, KEK";
+      description = "PKI bundle containing db, PK, KEK";
     };
     publicKeyFile = mkOption {
       type = types.path;

--- a/rust/tool/src/gc.rs
+++ b/rust/tool/src/gc.rs
@@ -149,7 +149,7 @@ mod tests {
     }
 
     #[test]
-    fn keep_used_dirctory_with_used_and_unused_file() -> Result<()> {
+    fn keep_used_directory_with_used_and_unused_file() -> Result<()> {
         let tmpdir = tempfile::tempdir()?;
         let rootdir = create_dir(tmpdir.path().join("root"))?;
 

--- a/rust/tool/src/generation.rs
+++ b/rust/tool/src/generation.rs
@@ -126,7 +126,7 @@ fn read_build_time(path: &Path) -> Result<String> {
 /// A link pointing to a generation.
 ///
 /// Can be built from a symlink in /nix/var/nix/profiles/ alone because the name of the
-/// symlink enocdes the version number.
+/// symlink encodes the version number.
 #[derive(Debug)]
 pub struct GenerationLink {
     pub version: u64,

--- a/rust/tool/src/pe.rs
+++ b/rust/tool/src/pe.rs
@@ -196,7 +196,7 @@ fn stub_offset(binary: &Path) -> Result<u64> {
 
     let image_base = image_base(&pe);
 
-    // The Virtual Memory Addresss (VMA) is relative to the image base, aka the image base
+    // The Virtual Memory Address (VMA) is relative to the image base, aka the image base
     // needs to be added to the virtual address to get the actual (but still virtual address)
     Ok(u64::from(
         pe.sections


### PR DESCRIPTION
None of us are native English speakers. This PR enables automatic typo checks in our tree. I've also fixed all typos that it found.