### PR TITLE
tool: smarter systemd-boot install 

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -59,6 +59,7 @@ in
         ''}
   
         ${cfg.package}/bin/lzbt install \
+          --systemd ${pkgs.systemd} \
           --public-key ${cfg.publicKeyFile} \
           --private-key ${cfg.privateKeyFile} \
           --configuration-limit ${toString configurationLimit} \

--- a/rust/tool/src/cli.rs
+++ b/rust/tool/src/cli.rs
@@ -19,6 +19,10 @@ enum Commands {
 
 #[derive(Parser)]
 struct InstallCommand {
+    /// Systemd path
+    #[arg(long)]
+    systemd: PathBuf,
+
     /// sbsign Public Key
     #[arg(long)]
     public_key: PathBuf,
@@ -60,6 +64,7 @@ fn install(args: InstallCommand) -> Result<()> {
 
     install::Installer::new(
         PathBuf::from(lanzaboote_stub),
+        args.systemd,
         key_pair,
         args.configuration_limit,
         args.esp,

--- a/rust/tool/src/signature.rs
+++ b/rust/tool/src/signature.rs
@@ -43,4 +43,30 @@ impl KeyPair {
 
         Ok(())
     }
+
+    /// Verify the signature of a PE binary. Return true if the signature was verified.
+    pub fn verify(&self, path: &Path) -> bool {
+        let args: Vec<OsString> = vec![
+            OsString::from("--cert"),
+            self.public_key.clone().into(),
+            path.as_os_str().to_owned(),
+        ];
+
+        let output = match Command::new("sbverify").args(&args).output() {
+            Ok(output) => output,
+            Err(_) => return false,
+        };
+
+        if !output.status.success() {
+            if std::io::stderr().write_all(&output.stderr).is_err() {
+                return false;
+            };
+            println!(
+                "Failed to verify signature using sbverify with args `{:?}`",
+                &args
+            );
+            return false;
+        }
+        true
+    }
 }

--- a/rust/tool/tests/common/mod.rs
+++ b/rust/tool/tests/common/mod.rs
@@ -1,7 +1,6 @@
 use std::ffi::OsStr;
 use std::fs;
 use std::io::Write;
-use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 
@@ -74,7 +73,6 @@ fn setup_toplevel(tmpdir: &Path) -> Result<PathBuf> {
 
     let initrd_path = toplevel.join("initrd");
     let kernel_path = toplevel.join("kernel");
-    let systemd_path = toplevel.join("systemd");
     let nixos_version_path = toplevel.join("nixos-version");
     let kernel_modules_path = toplevel.join("kernel-modules/lib/modules/6.1.1");
 
@@ -84,7 +82,6 @@ fn setup_toplevel(tmpdir: &Path) -> Result<PathBuf> {
     // in isolation this should suffice.
     fs::copy(&test_systemd_stub, initrd_path)?;
     fs::copy(&test_systemd_stub, kernel_path)?;
-    symlink(&test_systemd, systemd_path)?;
     fs::write(nixos_version_path, b"23.05")?;
     fs::create_dir_all(kernel_modules_path)?;
 
@@ -114,6 +111,8 @@ pub fn lanzaboote_install(
     let output = cmd
         .env("LANZABOOTE_STUB", test_systemd_stub)
         .arg("install")
+        .arg("--systemd")
+        .arg(test_systemd)
         .arg("--public-key")
         .arg("tests/fixtures/uefi-keys/db.pem")
         .arg("--private-key")

--- a/rust/tool/tests/systemd_boot.rs
+++ b/rust/tool/tests/systemd_boot.rs
@@ -1,0 +1,155 @@
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::{fs, os::unix::prelude::MetadataExt};
+
+use anyhow::Result;
+use tempfile::tempdir;
+
+mod common;
+
+#[test]
+fn keep_systemd_boot_binaries() -> Result<()> {
+    let esp = tempdir()?;
+    let tmpdir = tempdir()?;
+    let profiles = tempdir()?;
+    let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
+        .expect("Failed to setup generation link");
+
+    let systemd_boot_path = systemd_boot_path(&esp);
+    let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
+
+    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+    assert!(output0.status.success());
+
+    // Use the modification time instead of a hash because the hash would be the same even if the
+    // file was overwritten.
+    let systemd_boot_mtime0 = mtime(&systemd_boot_path);
+    let systemd_boot_fallback_mtime0 = mtime(&systemd_boot_fallback_path);
+
+    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+    assert!(output1.status.success());
+
+    let systemd_boot_mtime1 = mtime(&systemd_boot_path);
+    let systemd_boot_fallback_mtime1 = mtime(&systemd_boot_fallback_path);
+
+    assert_eq!(
+        systemd_boot_mtime0, systemd_boot_mtime1,
+        "systemd-boot binary was modified on second install."
+    );
+    assert_eq!(
+        systemd_boot_fallback_mtime0, systemd_boot_fallback_mtime1,
+        "systemd-boot fallback binary was moidified on second install."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn overwrite_malformed_systemd_boot_binaries() -> Result<()> {
+    let esp = tempdir()?;
+    let tmpdir = tempdir()?;
+    let profiles = tempdir()?;
+    let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
+        .expect("Failed to setup generation link");
+
+    let systemd_boot_path = systemd_boot_path(&esp);
+    let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
+
+    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+    assert!(output0.status.success());
+
+    // Make systemd-boot binaries malformed by truncating them.
+    fs::File::create(&systemd_boot_path)?;
+    fs::File::create(&systemd_boot_fallback_path)?;
+
+    let malformed_systemd_boot_hash = hash_file(&systemd_boot_path);
+    let malformed_systemd_boot_fallback_hash = hash_file(&systemd_boot_fallback_path);
+
+    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+    assert!(output1.status.success());
+
+    let systemd_boot_hash = hash_file(&systemd_boot_path);
+    let systemd_boot_fallback_hash = hash_file(&systemd_boot_fallback_path);
+
+    assert_ne!(
+        malformed_systemd_boot_hash, systemd_boot_hash,
+        "Malformed systemd-boot binaries were not replaced."
+    );
+    assert_ne!(
+        malformed_systemd_boot_fallback_hash, systemd_boot_fallback_hash,
+        "Maformed systemd-boot fallback binaries were not replaced."
+    );
+
+    Ok(())
+}
+
+#[test]
+fn overwrite_unsigned_systemd_boot_binaries() -> Result<()> {
+    let esp = tempdir()?;
+    let tmpdir = tempdir()?;
+    let profiles = tempdir()?;
+    let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
+        .expect("Failed to setup generation link");
+
+    let systemd_boot_path = systemd_boot_path(&esp);
+    let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
+
+    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+    assert!(output0.status.success());
+
+    remove_signature(&systemd_boot_path)?;
+    remove_signature(&systemd_boot_fallback_path)?;
+    assert!(!verify_signature(&systemd_boot_path)?);
+    assert!(!verify_signature(&systemd_boot_fallback_path)?);
+
+    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+    assert!(output1.status.success());
+
+    assert!(verify_signature(&systemd_boot_path)?);
+    assert!(verify_signature(&systemd_boot_fallback_path)?);
+
+    Ok(())
+}
+
+fn systemd_boot_path(esp: &tempfile::TempDir) -> PathBuf {
+    esp.path().join("EFI/systemd/systemd-bootx64.efi")
+}
+
+fn systemd_boot_fallback_path(esp: &tempfile::TempDir) -> PathBuf {
+    esp.path().join("EFI/BOOT/BOOTX64.EFI")
+}
+
+/// Look up the modification time (mtime) of a file.
+fn mtime(path: &Path) -> i64 {
+    fs::metadata(path)
+        .expect("Failed to read modification time.")
+        .mtime()
+}
+
+fn hash_file(path: &Path) -> sha2::digest::Output<Sha256> {
+    Sha256::digest(fs::read(path).expect("Failed to read file to hash."))
+}
+
+/// Remove signature from a signed PE file.
+pub fn remove_signature(path: &Path) -> Result<()> {
+    let output = Command::new("sbattach")
+        .arg("--remove")
+        .arg(path.as_os_str())
+        .output()?;
+    print!("{}", String::from_utf8(output.stdout)?);
+    print!("{}", String::from_utf8(output.stderr)?);
+    Ok(())
+}
+
+/// Verify signature of PE file.
+pub fn verify_signature(path: &Path) -> Result<bool> {
+    let output = Command::new("sbverify")
+        .arg(path.as_os_str())
+        .arg("--cert")
+        .arg("tests/fixtures/uefi-keys/db.pem")
+        .output()?;
+    print!("{}", String::from_utf8(output.stdout)?);
+    print!("{}", String::from_utf8(output.stderr)?);
+    Ok(output.status.success())
+}


### PR DESCRIPTION
The process of installing systemd-boot is "smarter" because it now
considers a a few conditions instead of doing nothing if there is a file
at the deistination path. systemd-boot is now forcibly installed (i.e.
overwriting any file at the destination) if (1) there is no file at the
destination, OR (2) a newer version of systemd-boot is available, OR (3)
the signature of the file at the destination could not be verified.

Fixes part of #39 

Will produce a small and easy to fix merge conflict with #75 