### PR TITLE
Fix CI Regression after Linux Loader Fix

### DIFF
--- a/nix/tests/lanzaboote.nix
+++ b/nix/tests/lanzaboote.nix
@@ -129,6 +129,7 @@ in
       src = "bootspec.get('kernel')";
       dst = "convert_to_esp(bootspec.get('kernel'))";
     };
+    appendCrap = true;
   };
 
   specialisation = mkSecureBootTest {


### PR DESCRIPTION
Now that we don't sign the kernel anymore, we need to manually invalidate its checksum.

This is a regression from #75. See https://github.com/nix-community/lanzaboote/pull/75#issuecomment-1413953437.