### PR TITLE
Add a More Complete Flakes Fragment for Quickstart

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -125,38 +125,57 @@ Below is a fragment of a NixOS configuration that enables the Secure
 Boot stack.
 
 ```nix
-nixosConfigurations = {
-  yourHost = nixpkgs.lib.nixosSystem {
-    system = "x86_64-linux";
+{
+  description = "A SecureBoot-enabled NixOS configurations";
 
-    modules = [
-      # ... other modules ...
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-      lanzaboote.nixosModules.lanzaboote
+    lanzaboote = {
+      url = "github:nix-community/lanzaboote";
 
-      ({ config, pkgs, lib, ... }: {
-        # This should already be here from switching to bootspec earlier.
-        # It's not required anymore, but also doesn't do any harm.
-        boot.bootspec.enable = true;
-
-        environment.systemPackages = [
-          # For debugging and troubleshooting Secure Boot.
-          pkgs.sbctl
-        ];
-
-        # Lanzaboote currently replaces the systemd-boot module.
-        # This setting is usually set to true in configuration.nix
-        # generated at installation time. So we force it to false
-        # for now.
-        boot.loader.systemd-boot.enable = lib.mkForce false;
-
-        boot.lanzaboote = {
-          enable = true;
-          pkiBundle = "/etc/secureboot";
-        };
-      })
-    ];
+      # Optional but recommended to limit the size of your system closure.
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
+
+  outputs = { self, nixpkgs, lanzaboote, ...}: {
+    nixosConfigurations = {
+      yourHost = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+
+        modules = [
+          # This is not a complete NixOS configuration and you need to reference
+          # your normal configuration here.
+
+          lanzaboote.nixosModules.lanzaboote
+
+          ({ pkgs, lib, ... }: {
+            # This should already be here from switching to bootspec earlier.
+            # It's not required anymore, but also doesn't do any harm.
+            boot.bootspec.enable = true;
+
+            environment.systemPackages = [
+              # For debugging and troubleshooting Secure Boot.
+              pkgs.sbctl
+            ];
+
+            # Lanzaboote currently replaces the systemd-boot module.
+            # This setting is usually set to true in configuration.nix
+            # generated at installation time. So we force it to false
+            # for now.
+            boot.loader.systemd-boot.enable = lib.mkForce false;
+
+            boot.lanzaboote = {
+              enable = true;
+              pkiBundle = "/etc/secureboot";
+            };
+          })
+        ];
+      };
+    };
+  };
+}
 ```
 
 After you rebuild your system, check `sbctl verify` output:


### PR DESCRIPTION
The Flakes configuration fragment in the quickstart documentation was not self-contained and implicitly assumed that a Flakes intput needs to be added. Make this more obvious.

Fixes #104.