### PR TITLE
tool: make some utility test functions reusable

### DIFF
--- a/rust/tool/tests/gc.rs
+++ b/rust/tool/tests/gc.rs
@@ -1,10 +1,12 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use tempfile::tempdir;
 
 mod common;
+
+use common::count_files;
 
 #[test]
 fn keep_only_configured_number_of_generations() -> Result<()> {
@@ -80,8 +82,4 @@ fn keep_unrelated_files_on_esp() -> Result<()> {
     assert!(unrelated_firmware.exists());
 
     Ok(())
-}
-
-fn count_files(path: &Path) -> Result<usize> {
-    Ok(fs::read_dir(path)?.count())
 }


### PR DESCRIPTION
This PR is part of a larger series which is supposed to be merged in order but is broken up into multiple pieces to make review easier. It is supposed to be merged in this order:

(#108) -> #107 -> #110 -> #109

Make the utility functions reusable by moving them to the common module.