### PR TITLE
Update Dependencies of Stub

### DIFF
--- a/rust/stub/Cargo.lock
+++ b/rust/stub/Cargo.lock
@@ -113,18 +113,38 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.21"
+name = "ptr_meta"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "bcada80daa06c42ed5f48c9a043865edea5dc44cbf9ac009fda3b89526e28607"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -162,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -188,21 +208,22 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b87700863d65dd4841556be3374d8d4f9f8dbb577ad93a39859e70b3b91f35"
+checksum = "f5607fef843201070ed442fa257c7a944fae963fac7d4620612123192eb4d844"
 dependencies = [
  "bitflags",
  "log",
+ "ptr_meta",
  "ucs2",
  "uefi-macros",
 ]
 
 [[package]]
 name = "uefi-macros"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275f054a1d9fd7e43a2ce91cc24298a87b281117dea8afc120ae95faa0e96b94"
+checksum = "f8099684193f2d99f7f130951f4054a1591ff7da370e2b33d7a71f0434920499"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -211,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-services"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f6e28d165193fb5da5230faec576f0be75c71ce6d171556a2775b3673094b4"
+checksum = "f75daa44f951cc1d9dc68d98cabc06ddbccc221d7bd21222271be5d7ac526a9d"
 dependencies = [
  "cfg-if",
  "log",
@@ -222,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "version_check"

--- a/rust/stub/Cargo.lock
+++ b/rust/stub/Cargo.lock
@@ -59,12 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-compact"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2d21333b679bbbac680b3eb45c86937e42f69277028f4e97b599b80b86c253"
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +83,6 @@ dependencies = [
 name = "lanzaboote_stub"
 version = "0.1.0"
 dependencies = [
- "ed25519-compact",
  "goblin",
  "log",
  "sha2",

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 uefi = { version = "0.18.0", default-features = false, features = [ "alloc", "exts" ] }
 uefi-services = { version = "0.15.0", default-features = false, features = [ "panic_handler" ] }
 log = "0.4.17"
-ed25519-compact = { version = "2.0.2", default-features = false, features = [] }
 goblin = { version = "0.6.0", default-features = false, features = [ "pe64", "alloc" ]}
 
 # Use software implementation because the UEFI target seems to need it.

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.18.0", default-features = false, features = [ "alloc", "exts" ] }
-uefi-services = { version = "0.15.0", default-features = false, features = [ "panic_handler" ] }
+uefi = { version = "0.19.1", default-features = false, features = [ "alloc", "global_allocator", "unstable" ] }
+uefi-services = { version = "0.16.0", default-features = false, features = [ "panic_handler" ] }
 log = "0.4.17"
 goblin = { version = "0.6.0", default-features = false, features = [ "pe64", "alloc" ]}
 

--- a/rust/stub/src/linux_loader.rs
+++ b/rust/stub/src/linux_loader.rs
@@ -12,9 +12,9 @@ use uefi::{
     prelude::BootServices,
     proto::{
         device_path::{DevicePath, FfiDevicePath},
-        Protocol,
+        unsafe_protocol,
     },
-    unsafe_guid, Handle, Identify, Result, ResultExt, Status,
+    Handle, Identify, Result, ResultExt, Status,
 };
 
 /// The Linux kernel's initrd loading device path.
@@ -49,8 +49,7 @@ static mut DEVICE_PATH_PROTOCOL: [u8; 24] = [
 ///
 /// This protocol has a single method to load a file.
 #[repr(C)]
-#[unsafe_guid("4006c0c1-fcb3-403e-996d-4a6c8724e06d")]
-#[derive(Protocol)]
+#[unsafe_protocol("4006c0c1-fcb3-403e-996d-4a6c8724e06d")]
 struct LoadFile2Protocol {
     load_file: unsafe extern "efiapi" fn(
         this: &mut LoadFile2Protocol,
@@ -123,6 +122,7 @@ impl InitrdLoader {
         let mut proto = Box::pin(LoadFile2Protocol {
             load_file: raw_load_file,
             initrd_data,
+            _no_send_or_sync: Default::default(),
         });
 
         // Linux finds the right handle by looking for something that


### PR DESCRIPTION
This PR updates the Rust dependencies of the stub. Most notably, it updates to the latest version of the `uefi` crate, which brings some minor breaking changes.