### PR TITLE
Properly handle fwupd update capsules

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sign all configurations that should be bootable.
 
 `lzbt` lives in `rust/tool`.
 
-### Stub 
+### Stub
 
 When the Linux kernel and initrd are packed into a UKI, they need an
 UEFI application stub. This role is typically filled by
@@ -88,6 +88,11 @@ signature on the Linux kernel and embedding a cryptographic hash of
 the initrd into the signed UKI.
 
 The stub lives in `rust/stub`.
+
+### Fwupd
+
+When both Lanzaboote and `services.fwupd` are enabled, `fwupd.service` will get a `preStart` that
+ensures a signed fwupd binary in /run that fwupd will use.
 
 ## State of Upstreaming to Nixpkgs
 


### PR DESCRIPTION
Closes #85
```
$ sudo sbctl verify
Verifying file database and EFI images in /boot...
✓ /boot/EFI/BOOT/BOOTX64.EFI is signed
✓ /boot/EFI/Linux/nixos-generation-553.efi is signed
✓ /boot/EFI/Linux/nixos-generation-554.efi is signed
✓ /boot/EFI/Linux/nixos-generation-555.efi is signed
✓ /boot/EFI/Linux/nixos-generation-556.efi is signed
✓ /boot/EFI/Linux/nixos-generation-557.efi is signed
✓ /boot/EFI/Linux/nixos-generation-558.efi is signed
✓ /boot/EFI/Linux/nixos-generation-559.efi is signed
✓ /boot/EFI/Linux/nixos-generation-560.efi is signed
✓ /boot/EFI/Linux/nixos-generation-561.efi is signed
✓ /boot/EFI/Linux/nixos-generation-562.efi is signed
✓ /boot/EFI/Linux/nixos-generation-563.efi is signed
✓ /boot/EFI/nixos/fwupdx64.efi is signed
✓ /boot/EFI/systemd/systemd-bootx64.efi is signed
```