### PR TITLE
Revert "Properly handle fwupd update capsules"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sign all configurations that should be bootable.
 
 `lzbt` lives in `rust/tool`.
 
-### Stub
+### Stub 
 
 When the Linux kernel and initrd are packed into a UKI, they need an
 UEFI application stub. This role is typically filled by
@@ -88,11 +88,6 @@ signature on the Linux kernel and embedding a cryptographic hash of
 the initrd into the signed UKI.
 
 The stub lives in `rust/stub`.
-
-### Fwupd
-
-When both Lanzaboote and `services.fwupd` are enabled, `fwupd.service` will get a `preStart` that
-ensures a signed fwupd binary in /run that fwupd will use.
 
 ## State of Upstreaming to Nixpkgs
 

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -13,10 +13,6 @@ let
     timeout ${toString timeout}
     console-mode ${config.boot.loader.systemd-boot.consoleMode}
   '';
-
-  # This is the fwupd-efi package. We need to get it this way because a user might override services.fwupd.package,
-  # which may cause pkgs.fwupd-efi to be a different package than what the fwupd package has as dependency.
-  fwupd-efi = builtins.head (builtins.filter (x: x.pname == "fwupd-efi") config.services.fwupd.package.buildInputs);
 in
 {
   options.boot.lanzaboote = {
@@ -67,7 +63,7 @@ in
           cp -r ${cfg.pkiBundle}/* /tmp/pki
           ${sbctlWithPki}/bin/sbctl enroll-keys --yes-this-might-brick-my-machine
         ''}
-
+  
         ${cfg.package}/bin/lzbt install \
           --systemd ${config.systemd.package} \
           --systemd-boot-loader-config ${systemdBootLoaderConfig} \
@@ -76,25 +72,6 @@ in
           --configuration-limit ${toString configurationLimit} \
           ${config.boot.loader.efi.efiSysMountPoint} \
           /nix/var/nix/profiles/system-*-link
-      '';
-    };
-
-    systemd.services.fwupd = lib.mkIf config.services.fwupd.enable {
-      # Tell fwupd to load its efi files from /run
-      environment.FWUPD_EFIAPPDIR = "/run/fwupd-efi";
-      serviceConfig.RuntimeDirectory = "fwupd-efi";
-      # Place the fwupd efi files in /run and sign them
-      preStart = ''
-        cp ${fwupd-efi}/libexec/fwupd/efi/fwupd*.efi /run/fwupd-efi/
-        ${pkgs.sbsigntool}/bin/sbsign --key '${cfg.privateKeyFile}' --cert '${cfg.publicKeyFile}' /run/fwupd-efi/fwupd*.efi
-      '';
-    };
-
-    # Disable support for the shim since we sign the binaries directly
-    environment.etc."fwupd/uefi_capsule.conf" = lib.mkIf config.services.fwupd.enable {
-      text = ''
-        [uefi_capsule]
-        DisableShimForSecureBoot=true
       '';
     };
   };


### PR DESCRIPTION
Reverts nix-community/lanzaboote#113. Users have reported issues:

```

error: The option `environment.etc."fwupd/uefi_capsule.conf".source' has conflicting definition values:
       - In `/nix/store/s2lni0idfkhs0lcnr8walzhdqzarfb0m-source/nixos/modules/system/etc/etc.nix': <derivation etc-uefi_capsule.conf>
       - In `/nix/store/s2lni0idfkhs0lcnr8walzhdqzarfb0m-source/nixos/modules/services/hardware/fwupd.nix': "/nix/store/nxv27wliyqqdxvp44mx715d2v568k9ym-fwupd-1.8.10/etc/fwupd/uefi_capsule.conf"
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```