### PR TITLE
Properly handle fwupd update capsules, take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sign all configurations that should be bootable.
 
 `lzbt` lives in `rust/tool`.
 
-### Stub 
+### Stub
 
 When the Linux kernel and initrd are packed into a UKI, they need an
 UEFI application stub. This role is typically filled by
@@ -88,6 +88,12 @@ signature on the Linux kernel and embedding a cryptographic hash of
 the initrd into the signed UKI.
 
 The stub lives in `rust/stub`.
+
+### Fwupd
+
+When both Lanzaboote and `services.fwupd` are enabled, for
+`fwupd.service` a `preStart` will be added that ensures a signed fwupd
+binary is placed in `/run` that fwupd will use.
 
 ## State of Upstreaming to Nixpkgs
 

--- a/flake.lock
+++ b/flake.lock
@@ -181,16 +181,16 @@
     },
     "nixpkgs-test": {
       "locked": {
-        "lastModified": 1671812130,
-        "narHash": "sha256-GALBK+qB9rhnB+lVnxdgtMoXCySXughZZ3+qGO1Ke/k=",
-        "owner": "RaitoBezarius",
+        "lastModified": 1679009563,
+        "narHash": "sha256-jizICiQOqUcYFNHRNNOo69bfyNo36iyuRAHem5z68LQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e51bf8cc8e2c75192e930ad83ed272938729e7be",
+        "rev": "371d3778c4f9cee7d5cf014e6ce400d57366570f",
         "type": "github"
       },
       "original": {
-        "owner": "RaitoBezarius",
-        "ref": "simplified-qemu-boot-disks",
+        "owner": "NixOS",
+        "ref": "qemu-boot-disk-using-make-disk-image",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
-    nixpkgs-test.url = "github:RaitoBezarius/nixpkgs/simplified-qemu-boot-disks";
+    nixpkgs-test.url = "github:NixOS/nixpkgs/qemu-boot-disk-using-make-disk-image";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 


### PR DESCRIPTION
This is a mostly verbatim copy of #113 (credit to @dasJ for most all of this) that has been updated to use NixOS/nixpkgs#220555 (which has hit nixos-unstable now). It has been successfully tested with a BIOS update (with secureboot enforcing) on a 12th-gen Framework

Also we probably should update the lockfile in this repo first (or let Renovate bot handle it), since this will probably fail eval without that PR