### PR TITLE
Don't Reload Stub from the File System

### DIFF
--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -177,6 +177,10 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
 
     print_logo();
 
+    // SAFETY: We get a slice that represents our currently running
+    // image and then parse the PE data structures from it. This is
+    // safe, because we don't touch any data in the data sections that
+    // might conceivably change while we look at the slice.
     let config: EmbeddedConfiguration = unsafe {
         EmbeddedConfiguration::new(
             booted_image_file(system_table.boot_services())

--- a/rust/stub/src/pe_section.rs
+++ b/rust/stub/src/pe_section.rs
@@ -6,25 +6,25 @@
 
 use alloc::{borrow::ToOwned, string::String};
 
-/// Extracts the data of a section of a PE file.
-pub fn pe_section<'a>(file_data: &'a [u8], section_name: &str) -> Option<&'a [u8]> {
-    let pe_binary = goblin::pe::PE::parse(file_data).ok()?;
+/// Extracts the data of a section of a loaded PE file.
+pub fn pe_section<'a>(pe_data: &'a [u8], section_name: &str) -> Option<&'a [u8]> {
+    let pe_binary = goblin::pe::PE::parse(pe_data).ok()?;
 
     pe_binary
         .sections
         .iter()
-        .find(|s| s.name().unwrap() == section_name)
+        .find(|s| s.name().map(|n| n == section_name).unwrap_or(false))
         .and_then(|s| {
-            let section_start: usize = s.pointer_to_raw_data.try_into().ok()?;
+            let section_start: usize = s.virtual_address.try_into().ok()?;
 
             assert!(s.virtual_size <= s.size_of_raw_data);
             let section_end: usize = section_start + usize::try_from(s.virtual_size).ok()?;
 
-            Some(&file_data[section_start..section_end])
+            Some(&pe_data[section_start..section_end])
         })
 }
 
-/// Extracts the data of a section of a PE file and returns it as a string.
-pub fn pe_section_as_string<'a>(file_data: &'a [u8], section_name: &str) -> Option<String> {
-    pe_section(file_data, section_name).map(|data| core::str::from_utf8(data).unwrap().to_owned())
+/// Extracts the data of a section of a loaded PE image and returns it as a string.
+pub fn pe_section_as_string<'a>(pe_data: &'a [u8], section_name: &str) -> Option<String> {
+    pe_section(pe_data, section_name).map(|data| core::str::from_utf8(data).unwrap().to_owned())
 }


### PR DESCRIPTION
... because this might not work, if we were not loaded from a file system. It also removes the issue where we might not load the signed image that was actually loaded. Parsing the PE file we are currently executing from does not really fit in to Rust's safety model. If the `unsafe` block I added is objectionable, we can copy the image in memory and parse it from there.

Fixes #123.