### PR TITLE
stub: make it compatible with a stable Rust compiler (≥ 1.68.x)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,8 +77,8 @@
 
           inherit (pkgs) lib;
 
-          rust-nightly = pkgs.rust-bin.fromRustupToolchainFile ./rust/stub/rust-toolchain.toml;
-          craneLib = crane.lib.x86_64-linux.overrideToolchain rust-nightly;
+          uefi-rust-stable = pkgs.rust-bin.fromRustupToolchainFile ./rust/stub/rust-toolchain.toml;
+          craneLib = crane.lib.x86_64-linux.overrideToolchain uefi-rust-stable;
 
           # Build attributes for a Rust application.
           buildRustApp =

--- a/rust/stub/Cargo.lock
+++ b/rust/stub/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "log"
@@ -113,9 +113,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -3,9 +3,11 @@ name = "lanzaboote_stub"
 version = "0.1.0"
 edition = "2021"
 publish = false
+# For UEFI target
+rust_version = "1.68"
 
 [dependencies]
-uefi = { version = "0.20.0", default-features = false, features = [ "alloc", "global_allocator", "unstable" ] }
+uefi = { version = "0.20.0", default-features = false, features = [ "alloc", "global_allocator" ] }
 uefi-services = { version = "0.17.0", default-features = false, features = [ "panic_handler", "logger" ] }
 goblin = { version = "0.6.1", default-features = false, features = [ "pe64", "alloc" ]}
 

--- a/rust/stub/rust-toolchain.toml
+++ b/rust/stub/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-03-10"
+channel = "1.68.2"
 components = [ "rust-src" ]
 targets = [ "x86_64-unknown-uefi" ]

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(negative_impls)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate alloc;


### PR DESCRIPTION
The stub (and the tool) uses a stable Rust compiler.