### PR TITLE
tool: Switch back to mtime

### DIFF
--- a/rust/tool/src/generation.rs
+++ b/rust/tool/src/generation.rs
@@ -96,7 +96,7 @@ impl fmt::Display for Generation {
 }
 
 fn read_build_time(path: &Path) -> Result<Date> {
-    let build_time = time::OffsetDateTime::from_unix_timestamp(fs::metadata(path)?.mtime())?.date();
+    let build_time = time::OffsetDateTime::from_unix_timestamp(fs::symlink_metadata(path)?.mtime())?.date();
     Ok(build_time)
 }
 

--- a/rust/tool/src/generation.rs
+++ b/rust/tool/src/generation.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::fs;
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
@@ -95,7 +96,7 @@ impl fmt::Display for Generation {
 }
 
 fn read_build_time(path: &Path) -> Result<Date> {
-    let build_time = time::OffsetDateTime::from(fs::metadata(path)?.created()?).date();
+    let build_time = time::OffsetDateTime::from_unix_timestamp(fs::metadata(path)?.mtime())?.date();
     Ok(build_time)
 }
 

--- a/rust/tool/tests/common/mod.rs
+++ b/rust/tool/tests/common/mod.rs
@@ -70,6 +70,9 @@ pub fn setup_generation_link_from_toplevel(
     let mut file = fs::File::create(bootspec_path)?;
     file.write_all(&serde_json::to_vec(&bootspec)?)?;
 
+    // Explicitly set modification time so that snapshot test of os-release reliably works.
+    // This has to happen after any modifications to the directory.
+    filetime::set_file_mtime(&generation_link_path, filetime::FileTime::zero())?;
     Ok(generation_link_path)
 }
 

--- a/rust/tool/tests/os_release.rs
+++ b/rust/tool/tests/os_release.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 use anyhow::{Context, Result};
+use expect_test::expect;
 use tempfile::tempdir;
 
 mod common;
@@ -14,9 +15,6 @@ fn generate_expected_os_release() -> Result<()> {
     let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
         .expect("Failed to setup generation link");
 
-    // Expect the 'Built on' date in VERSION_ID to be from the birth time of generation_link
-    let expected_built_on = time::OffsetDateTime::from(fs::metadata(generation_link.as_path())?.created()?).date();
-
     let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), vec![generation_link])?;
     assert!(output0.status.success());
 
@@ -29,12 +27,13 @@ fn generate_expected_os_release() -> Result<()> {
         .context("Failed to read .osrelease PE section.")?
         .to_owned();
 
-    let expected_os_release_section = format!(r#"ID=lanza
-PRETTY_NAME=LanzaOS
-VERSION_ID=Generation 1, Built on {}
-"#, expected_built_on.to_string());
+    let expected = expect![[r#"
+        ID=lanza
+        PRETTY_NAME=LanzaOS
+        VERSION_ID=Generation 1, Built on 1970-01-01
+    "#]];
 
-    assert_eq!(&expected_os_release_section, &String::from_utf8(os_release_section)?);
+    expected.assert_eq(&String::from_utf8(os_release_section)?);
 
     Ok(())
 }


### PR DESCRIPTION
We kinda need this because XFS doesn't appear to support birth time:
```
running 15 tests
test esp::tests::nixos_path_creates_correct_filename_from_nix_store_path ... ok
test gc::tests::delete_empty_unused_directory ... ok
test gc::tests::delete_unused_directory_with_unused_file_inside ... ok
test gc::tests::delete_unused_file ... ok
test generation::tests::parse_version_correctly ... ok
test gc::tests::keep_used_file ... ok
test os_release::tests::escaping_works ... ok
test gc::tests::only_delete_filtered_unused_files ... ok
test os_release::tests::parses_correctly_from_str ... ok
test gc::tests::keep_used_directory_with_used_and_unused_file ... ok
test pe::tests::convert_to_valid_uefi_path ... ok
test pe::tests::convert_to_valid_uefi_path_relative_to_esp ... ok
test systemd::tests::compare_version_correctly ... ok
test systemd::tests::fail_to_parse_version ... ok
test systemd::tests::parse_version_correctly ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/gc.rs (target/release/deps/gc-0baf904aefee7e61)

running 2 tests
test keep_only_configured_number_of_generations ... ok
test keep_unrelated_files_on_esp ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.37s

     Running tests/install.rs (target/release/deps/install-5a1b29efda2ec3fe)

running 3 tests
test overwrite_unsigned_files ... ok
test do_not_install_duplicates ... ok
test overwrite_unsigned_images ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

     Running tests/os_release.rs (target/release/deps/os_release-e408e464bb6ad5d2)

running 1 test
test generate_expected_os_release ... FAILED

failures:

---- generate_expected_os_release stdout ----
Error: creation time is not available for the filesystem


failures:
    generate_expected_os_release

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

cc @nikstur @blitz 