### PR TITLE
tool: disable gc in the presence of malformed gens

### DIFF
--- a/rust/tool/Cargo.lock
+++ b/rust/tool/Cargo.lock
@@ -474,6 +474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +547,7 @@ dependencies = [
  "fastrand",
  "filetime",
  "goblin",
+ "indoc",
  "log",
  "nix",
  "rand",

--- a/rust/tool/Cargo.toml
+++ b/rust/tool/Cargo.toml
@@ -27,6 +27,7 @@ sha2 = "0.10.6"
 fastrand = "1.9.0"
 log = { version = "0.4.17", features = ["std"] }
 stderrlog = "0.5.4"
+indoc = "2.0.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"


### PR DESCRIPTION
Disable GC if there are any malformed gens to avoid catastrophic failure when there are upstream changes to NixOS that are not handled in lzbt.

Suggested by @alois31 

Closes #127 