### PR TITLE
feat: enable synthesis support

### DIFF
--- a/nix/tests/lanzaboote.nix
+++ b/nix/tests/lanzaboote.nix
@@ -239,6 +239,18 @@ in
     '';
   };
 
+  # We test if we can install Lanzaboote without Bootspec support.
+  synthesis = mkSecureBootTest {
+    name = "lanzaboote-synthesis";
+    machine = { lib, ... }: {
+      boot.bootspec.enable = lib.mkForce false;
+    };
+    testScript = ''
+      machine.start()
+      assert "Secure Boot: enabled (user)" in machine.succeed("bootctl status")
+    '';
+  };
+
   systemd-boot-loader-config = mkSecureBootTest {
     name = "lanzaboote-systemd-boot-loader-config";
     machine = {


### PR DESCRIPTION
Bootspec has a mechanism called synthesis where you can synthesize bootspecs if they are not present based on the generation link only.

This is useful for "vanilla bootspec" which does not contain any extensions, as this is what we do right now.

If we need extensions, we can also implement our synthesis mechanism on the top of it.

Enabling synthesis gives us the superpower to support non-bootspec users. :-)