### PR TITLE
feat: add CPIO packing for companion files

### DIFF
--- a/nix/tests/lanzaboote.nix
+++ b/nix/tests/lanzaboote.nix
@@ -267,4 +267,63 @@ in
         f"Expected: {expected_loader_config} is not included in actual config: '{actual_loader_config}'"
     '';
   };
+
+  export-efi-variables = mkSecureBootTest {
+    name = "lanzaboote-exports-efi-variables";
+    testScript = ''
+      import struct
+
+      machine.start()
+      SD_LOADER_GUID = "4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+      expected_variables = ["LoaderDevicePartUUID",
+        "LoaderImageIdentifier",
+        "LoaderFirmwareInfo",
+        "LoaderFirmwareType",
+        "StubInfo",
+        "StubFeatures"
+      ]
+
+      def read_raw_variable(var: str) -> bytes:
+          attr_var = machine.succeed(f"cat /sys/firmware/efi/efivars/{var}-{SD_LOADER_GUID}").encode('raw_unicode_escape')
+          _ = attr_var[:4] # First 4 bytes are attributes according to https://www.kernel.org/doc/html/latest/filesystems/efivarfs.html
+          value = attr_var[4:]
+          return value
+      def read_string_variable(var: str, encoding='utf-16-le') -> str:
+          return read_raw_variable(var).decode(encoding)
+      def assert_variable_string(var: str, expected: str):
+          value = read_string_variable(var)
+          assert value == expected, f"Unexpected variable value in `{var}`, expected: `{expected.encode()!r}`, actual: `{value.encode()!r}`"
+      def assert_variable_string_contains(var: str, expected_substring: str):
+          value = read_string_variable(var).strip()
+          assert expected_substring in value, f"Did not find expected substring in `{var}`, expected substring: `{expected_substring}`, actual value: `{value}`"
+
+
+      print(machine.succeed(f"ls /sys/firmware/efi/efivars/*-{SD_LOADER_GUID}"))
+
+      with subtest("Check if variables are exported"):
+          for expected_var in expected_variables:
+              machine.succeed(f"test -e /sys/firmware/efi/efivars/{expected_var}-{SD_LOADER_GUID}")
+
+      with subtest("Is `StubInfo` correctly set"):
+          assert "lanzastub" in read_string_variable("StubInfo", 'utf8'), "Unexpected stub information, provenance is not lanzaboote project!"
+
+      with subtest("Is `LoaderImageIdentifier` correctly set"):
+        assert_variable_string("LoaderImageIdentifier", "\\EFI\\BOOT\\BOOTX64.EFI")
+
+      with subtest("Is `LoaderDevicePartUUID` correctly set"):
+        # TODO: exploit QEMU test infrastructure to pass the good value all the time.
+        assert_variable_string("LoaderImagePartUUID", "1c06f03b-704e-4657-b9cd-681a087a2fdc")
+
+      with subtest("Is `LoaderFirmwareInfo` correctly set"):
+        # OVMF tests are using EDK II tree.
+        assert_variable_string_contains("LoaderFirmwareInfo", "EDK II")
+
+      with subtest("Is `LoaderFirmwareType` reporting UEFI"):
+        assert_variable_string_contains("LoaderFirmwareType", "UEFI")
+
+      with subtest("Is `StubFeatures` non-zero"):
+          print(read_raw_variable("StubFeatures"))
+          assert struct.unpack('<Q', read_raw_variable("StubFeatures")) != 0
+    '';
+  };
 }

--- a/rust/stub/Cargo.lock
+++ b/rust/stub/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "bitflags 2.2.1",
  "goblin",
  "log",
+ "sha1_smol",
  "sha2",
  "uefi",
  "uefi-services",
@@ -175,6 +176,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"

--- a/rust/stub/Cargo.lock
+++ b/rust/stub/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "acid_io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e08a77c8b11dbd46fd3ba4f0aa0bf7ed078793201540779b0841a297acdad2c"
+dependencies = [
+ "byteorder",
+ "libc",
+ "memchr",
+ "windows",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +40,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cfg-if"
@@ -89,6 +107,7 @@ dependencies = [
 name = "lanzaboote_stub"
 version = "0.1.0"
 dependencies = [
+ "acid_io",
  "bitflags 2.2.1",
  "goblin",
  "log",
@@ -112,6 +131,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "plain"
@@ -266,3 +291,46 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "windows"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"

--- a/rust/stub/Cargo.lock
+++ b/rust/stub/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,9 +37,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -83,6 +89,7 @@ dependencies = [
 name = "lanzaboote_stub"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.2.1",
  "goblin",
  "log",
  "sha2",
@@ -92,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "log"
@@ -212,7 +219,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab39d5e7740f21ed4c46d6659f31038bbe3fe7a8be1f702d8a984348837c43b1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "log",
  "ptr_meta",
  "ucs2",

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 # For UEFI target
-rust_version = "1.68"
+rust-version = "1.68"
 
 [dependencies]
 uefi = { version = "0.20.0", default-features = false, features = [ "alloc", "global_allocator" ] }

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -19,6 +19,9 @@ log = { version = "0.4.17", default-features = false, features = [ "max_level_in
 sha2 = { version = "0.10.6", default-features = false, features = ["force-soft"] }
 # SHA1 for TPM TCG interface version 1.
 sha1_smol = "1.0.0"
+# std::io for alloc/no_std
+# FIXME: I don't want this extra dependency actually.
+acid_io = { version = "0.1.0", features = [ "alloc", "byteorder" ] }
 
 [profile.release]
 opt-level = "s"

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -17,6 +17,8 @@ log = { version = "0.4.17", default-features = false, features = [ "max_level_in
 
 # Use software implementation because the UEFI target seems to need it.
 sha2 = { version = "0.10.6", default-features = false, features = ["force-soft"] }
+# SHA1 for TPM TCG interface version 1.
+sha1_smol = "1.0.0"
 
 [profile.release]
 opt-level = "s"

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -10,6 +10,7 @@ rust_version = "1.68"
 uefi = { version = "0.20.0", default-features = false, features = [ "alloc", "global_allocator" ] }
 uefi-services = { version = "0.17.0", default-features = false, features = [ "panic_handler", "logger" ] }
 goblin = { version = "0.6.1", default-features = false, features = [ "pe64", "alloc" ]}
+bitflags = "2.2.1"
 
 # Even in debug builds, we don't enable the debug logs, because they generate a lot of spam from goblin.
 log = { version = "0.4.17", default-features = false, features = [ "max_level_info", "release_max_level_warn" ]}

--- a/rust/stub/src/cpio.rs
+++ b/rust/stub/src/cpio.rs
@@ -1,0 +1,241 @@
+use uefi::CStr16;
+use alloc::{vec::Vec, string::String};
+use acid_io::{byteorder::WriteBytesExt, {Cursor, Write}, Result};
+
+const MAGIC_NUMBER: &[u8] = b"070701";
+const TRAILER_NAME: &str= "TRAILER!!!";
+static CPIO_HEX: _ = "0123456789abcdef";
+
+struct Entry {
+    name: String,
+    ino: u32,
+    mode: u32,
+    uid: u32,
+    gid: u32,
+    nlink: u32,
+    mtime: u32,
+    file_size: u32,
+    dev_major: u32,
+    dev_minor: u32,
+    rdev_major: u32,
+    rdev_minor: u32,
+}
+
+fn compute_pad4(len: usize) -> Option<Vec<u8>> {
+    let overhang = len % 4;
+    if overhang != 0 {
+        let repeat = 4 - overhang;
+        Some(vec![0u8; repeat])
+    } else {
+        None
+    }
+}
+
+trait WriteBytesExt : Write {
+    fn write_cpio_word(&mut self, word: u32) -> Result<(), acid_io::Error> {
+        // A CPIO word is the hex(word) written as chars.
+        // We do it manually because format! will allocate.
+        self.write_all(
+            word.to_le_bytes()
+            .into_iter()
+            .enumerate()
+            .map(|(i, c)| CPIO_HEX[(c >> (4 * i)) & 0xF])
+            .rev()
+        )
+    }
+
+    fn write_cpio_header(&mut self, entry: Entry) -> Result<usize, acid_io::Error> {
+        let mut header_size = HEADER_LEN;
+        self.write_cpio_word(MAGIC_NUMBER)?;
+        self.write_cpio_word(entry.ino)?;
+        self.write_cpio_word(entry.mode)?;
+        self.write_cpio_word(entry.uid)?;
+        self.write_cpio_word(entry.gid)?;
+        self.write_cpio_word(entry.nlink)?;
+        self.write_cpio_word(entry.mtime)?;
+        self.write_cpio_word(entry.file_size)?;
+        self.write_cpio_word(entry.dev_major)?;
+        self.write_cpio_word(entry.dev_minor)?;
+        self.write_cpio_word(entry.rdev_major)?;
+        self.write_cpio_word(entry.rdev_minor)?;
+        self.write_cpio_word(entry.name.len() + 1)?;
+        self.write_cpio_word(0)?; // CRC
+        self.write(entry.name)?;
+        header_size += entry.name();
+        self.write(0u8)?; // Write \0 for the string.
+        // Pad to a multiple of 4 bytes
+        if let Some(pad) = compute_pad4(HEADER_LEN + name.len()) {
+            self.write_all(pad)?;
+            header_size += pad.len();
+        }
+        Ok(header_size)
+    }
+
+    fn write_cpio_contents(&mut self, header_size: usize, contents: &[u8]) -> Result<usize, acid_io::Error> {
+        let mut total_size = header_size + contents.len();
+        self.write_all(contents)?;
+        if let Some(pad) = compute_pad4(total_size) {
+            self.write_all(pad)?;
+            total_size += pad.len();
+        }
+        Ok(total_size)
+    }
+
+    fn write_cpio_entry(&mut self, header: Entry, contents: &[u8]) -> Result<usize, acid_io::Error> {
+        let header_size = self.write_cpio_header(entry)?;
+
+        self.write_cpio_contents(header_size, contents)
+    }
+}
+
+impl <W: Write + ?Sized> WriteBytesExt for W {}
+
+
+struct Cpio {
+    buffer: Vec<u8>,
+    inode_counter: u32
+}
+
+impl Cpio {
+    fn pack_one(&mut self, fname: &CStr16, contents: &[u8], target_dir_prefix: &str, access_mode: u32) -> uefi::Result
+        {
+            // cpio cannot deal with > 32 bits file sizes
+            // SAFETY: u32::MAX as usize can wrap if usize < u32.
+            // hopefully, I will never encounter a usize = u16 in the wild.
+            if contents.len() > (u32::MAX as usize) {
+                return Err(uefi::Status::LOAD_ERROR.into());
+            }
+
+            // cpio cannot deal with > 2^32 - 1 inodes neither
+            if self.inode_counter == u32::MAX {
+                return Err(uefi::Status::OUT_OF_RESOURCES.into());
+            }
+
+            // replace by mem::size_of
+            let mut current_len = 6 + 13 * 8 + 1 + 1;
+
+            if current_len > usize::MAX - target_dir_prefix.len() {
+                return Err(uefi::Status::OUT_OF_RESOURCES.into());
+            }
+
+            current_len += target_dir_prefix.len();
+
+            if current_len > usize::MAX - fname.num_bytes() {
+                return Err(uefi::Status::OUT_OF_RESOURCES.into());
+            }
+
+            current_len += fname.num_bytes();
+
+            // SAFETY: u32::MAX as usize can wrap if usize < u32.
+            if target_dir_prefix.len() + fname.num_bytes() >= (u32::MAX as usize) {
+                return Err(uefi::Status::OUT_OF_RESOURCES.into());
+            }
+
+            // Perform 4-byte alignment of current_len
+
+            if current_len == usize::MAX {
+                return Err(uefi::Status::OUT_OF_RESOURCES.into());
+            }
+
+            // Perform 4-byte alignment of contents.len()
+            let aligned_contents_len = contents.len();
+            if aligned_contents_len == usize::MAX {
+                return Err(uefi::Status::OUT_OF_RESOURCES.into());
+            }
+
+            if current_len > usize::MAX - aligned_contents_len {
+                return Err(uefi::Status::OUT_OF_RESOURCES.into());
+            }
+
+            current_len += aligned_contents_len;
+
+            if self.buffer.len() > usize::MAX - current_len {
+                return Err(uefi::Status::OUT_OF_RESOURCES.into());
+            }
+
+            // Perform re-allocation now.
+            let mut elt_buffer: Vec<u8> = Vec::with_capacity(current_len);
+            let cur = Cursor::new(&mut elt_buffer);
+
+            self.inode_counter += 1;
+            // TODO: perform the concat properly
+            // transform fname to string
+            cur.write_cpio_entry(Entry {
+                name: target_dir_prefix + "/" + fname,
+                ino: self.inode_counter,
+                mode: access_mode | 0100000, // S_IFREG
+                uid: 0,
+                gid: 0,
+                nlink: 1,
+                mtime: 0,
+                file_size: contents.len(),
+                dev_major: 0,
+                dev_minor: 0,
+                rdev_major: 0,
+                rdev_minor: 0
+            }, contents)?;
+
+            // Concat the element buffer.
+            self.buffer.append(&mut element_buffer);
+
+            Ok(())
+        }
+    fn pack_dir(&mut self, path: &str, access_mode: u32) -> uefi::Result {
+        // cpio cannot deal with > 2^32 - 1 inodes neither
+        if self.inode_counter == u32::MAX {
+            return Err(uefi::Status::OUT_OF_RESOURCES.into());
+        }
+
+        let current_len = 6 + 13 * 8 + 1;
+        if current_len > usize::MAX - path.len() {
+            return Err(uefi::Status::OUT_OF_RESOURCES.into());
+        }
+
+        current_len += path.len();
+
+        // Align the whole header
+        if self.buffer.len() == usize::MAX || self.buffer.len() > usize::MAX - current_len {
+            return Err(uefi::Status::OUT_OF_RESOURCES.into());
+        }
+
+        let mut elt_buffer: Vec<u8> = Vec::with_capacity(current_len);
+        let cur = Cursor::new(&mut elt_buffer);
+
+        cur.write_cpio_header(Entry {
+            name: path.into(),
+            ino: self.inode_counter,
+            mode: access_mode | 0100000, // S_IFREG
+            uid: 0,
+            gid: 0,
+            nlink: 1,
+            mtime: 0,
+            file_size: 0,
+            dev_major: 0,
+            dev_minor: 0,
+            rdev_major: 0,
+            rdev_minor: 0
+        })?;
+
+        // Concat the element buffer.
+        self.buffer.append(&mut element_buffer);
+
+        Ok(())
+    }
+
+    fn pack_prefix(&mut self, path: &str, dir_mode: u32) -> uefi::Result {
+        // Iterate over all parts of `path`
+        // pack_dir it
+        Ok(())
+    }
+
+    fn pack_trailer(&mut self) -> uefi::Result {
+        self.pack_one("", TRAILER_NAME, "", 0x0)
+    }
+}
+
+
+fn pack_cpio() {
+}
+
+fn pack_cpio_literal() {
+}

--- a/rust/stub/src/device_path_util.rs
+++ b/rust/stub/src/device_path_util.rs
@@ -1,0 +1,5 @@
+use uefi::{cstr16, Result, proto::device_path::DevicePath, CString16};
+
+// FIXME: should this be upstreamed to uefi-rs?
+pub fn device_path_to_str(dp: &DevicePath) -> Result<CString16> {
+}

--- a/rust/stub/src/device_path_util.rs
+++ b/rust/stub/src/device_path_util.rs
@@ -1,5 +1,0 @@
-use uefi::{cstr16, Result, proto::device_path::DevicePath, CString16};
-
-// FIXME: should this be upstreamed to uefi-rs?
-pub fn device_path_to_str(dp: &DevicePath) -> Result<CString16> {
-}

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -19,6 +19,7 @@ use measure::measure_image;
 use pe_loader::Image;
 use pe_section::{pe_section, pe_section_as_string};
 use sha2::{Digest, Sha256};
+use tpm::tpm_available;
 use uefi::{
     prelude::*,
     proto::{
@@ -240,6 +241,10 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
 
     if !is_initrd_hash_correct {
         warn!("Hash mismatch for initrd!");
+    }
+
+    if tpm_available(system_table.boot_services()) {
+        debug!("TPM available, will proceed to measurements.");
     }
 
     if let Ok(features) = get_loader_features(system_table.runtime_services()) {

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -9,9 +9,12 @@ mod pe_loader;
 mod pe_section;
 mod uefi_helpers;
 mod part_discovery;
+mod measure;
+mod unified_sections;
 
 use alloc::vec::Vec;
 use log::{info, warn, debug};
+use measure::measure_image;
 use pe_loader::Image;
 use pe_section::{pe_section, pe_section_as_string};
 use sha2::{Digest, Sha256};
@@ -244,6 +247,16 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
             debug!("Random seed is available, but lanzaboote does not support it yet.");
         }
     }
+
+    unsafe {
+        // Iterate over unified sections and measure them
+        let _ = measure_image(system_table.runtime_services(), booted_image_file(
+            system_table.boot_services()
+        ).unwrap()).expect("Failed to measure the image");
+        // TODO: Measure kernel parameters
+        // TODO: Measure sysexts
+    }
+
     export_efi_variables(&system_table)
         .expect("Failed to export stub EFI variables");
 

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -9,7 +9,6 @@ mod pe_loader;
 mod pe_section;
 mod uefi_helpers;
 mod part_discovery;
-mod device_path_util;
 
 use alloc::vec::Vec;
 use log::{info, warn};

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -8,6 +8,8 @@ mod linux_loader;
 mod pe_loader;
 mod pe_section;
 mod uefi_helpers;
+mod part_discovery;
+mod device_path_util;
 
 use alloc::vec::Vec;
 use log::{info, warn};
@@ -22,6 +24,7 @@ use uefi::{
     },
     CStr16, CString16, Result,
 };
+use uefi_helpers::export_efi_variables;
 
 use crate::{
     linux_loader::InitrdLoader,
@@ -235,6 +238,8 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     if !is_initrd_hash_correct {
         warn!("Hash mismatch for initrd!");
     }
+
+    export_efi_variables(&system_table)?;
 
     if is_kernel_hash_correct && is_initrd_hash_correct {
         boot_linux_unchecked(

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -12,6 +12,7 @@ mod part_discovery;
 mod measure;
 mod unified_sections;
 mod tpm;
+mod cpio;
 
 use alloc::vec::Vec;
 use log::{info, warn, debug};

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -11,7 +11,7 @@ mod uefi_helpers;
 mod part_discovery;
 
 use alloc::vec::Vec;
-use log::{info, warn};
+use log::{info, warn, debug};
 use pe_loader::Image;
 use pe_section::{pe_section, pe_section_as_string};
 use sha2::{Digest, Sha256};
@@ -241,6 +241,7 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     if let Ok(features) = get_loader_features(system_table.runtime_services()) {
         if features.contains(SystemdLoaderFeatures::RandomSeed) {
             // FIXME: process random seed then on the disk.
+            debug!("Random seed is available, but lanzaboote does not support it yet.");
         }
     }
     export_efi_variables(&system_table)

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -11,6 +11,7 @@ mod uefi_helpers;
 mod part_discovery;
 mod measure;
 mod unified_sections;
+mod tpm;
 
 use alloc::vec::Vec;
 use log::{info, warn, debug};
@@ -250,7 +251,7 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
 
     unsafe {
         // Iterate over unified sections and measure them
-        let _ = measure_image(system_table.runtime_services(), booted_image_file(
+        let _ = measure_image(&system_table, booted_image_file(
             system_table.boot_services()
         ).unwrap()).expect("Failed to measure the image");
         // TODO: Measure kernel parameters

--- a/rust/stub/src/measure.rs
+++ b/rust/stub/src/measure.rs
@@ -16,7 +16,7 @@ pub unsafe fn measure_image(
 
     let mut measurements = 0;
     for section in pe.sections {
-        let section_name = section.name().map_err(|err| uefi::Status::UNSUPPORTED)?;
+        let section_name = section.name().map_err(|_err| uefi::Status::UNSUPPORTED)?;
         if let Ok(unified_section) = UnifiedSection::try_from(section_name) {
             // UNSTABLE: && in the previous if is an unstable feature
             // https://github.com/rust-lang/rust/issues/53667

--- a/rust/stub/src/measure.rs
+++ b/rust/stub/src/measure.rs
@@ -39,7 +39,7 @@ pub unsafe fn measure_image(
             &SD_LOADER,
             VariableAttributes::from_bits_truncate(0x0),
             &TPM_PCR_INDEX_KERNEL_IMAGE.0.to_le_bytes()
-        );
+        )?;
     }
 
     Ok(measurements)

--- a/rust/stub/src/measure.rs
+++ b/rust/stub/src/measure.rs
@@ -12,7 +12,7 @@ pub unsafe fn measure_image(
 
     let pe_binary = unsafe { image.as_slice() };
     let pe = goblin::pe::PE::parse(pe_binary)
-        .map_err(|err| uefi::Status::LOAD_ERROR)?;
+        .map_err(|_err| uefi::Status::LOAD_ERROR)?;
 
     let mut measurements = 0;
     for section in pe.sections {

--- a/rust/stub/src/measure.rs
+++ b/rust/stub/src/measure.rs
@@ -1,11 +1,15 @@
-use uefi::{prelude::RuntimeServices, table::runtime::VariableAttributes, cstr16};
+use uefi::{table::{runtime::VariableAttributes, Boot, SystemTable}, cstr16, proto::tcg::PcrIndex};
 
-use crate::{uefi_helpers::{PeInMemory, SD_LOADER}, pe_section::pe_section_data, unified_sections::UnifiedSection};
+use crate::{uefi_helpers::{PeInMemory, SD_LOADER}, pe_section::pe_section_data, unified_sections::UnifiedSection, tpm::tpm_log_event_ascii};
 
-const TPM_PCR_INDEX_KERNEL_IMAGE: u8 = 11;
+const TPM_PCR_INDEX_KERNEL_IMAGE: PcrIndex = PcrIndex(11);
 
-pub unsafe fn measure_image(runtime_services: &RuntimeServices,
+pub unsafe fn measure_image(
+    system_table: &SystemTable<Boot>,
     image: PeInMemory) -> uefi::Result<u32> {
+    let runtime_services = system_table.runtime_services();
+    let boot_services = system_table.boot_services();
+
     let pe_binary = unsafe { image.as_slice() };
     let pe = goblin::pe::PE::parse(pe_binary)
         .map_err(|err| uefi::Status::LOAD_ERROR)?;
@@ -17,10 +21,12 @@ pub unsafe fn measure_image(runtime_services: &RuntimeServices,
             // UNSTABLE: && in the previous if is an unstable feature
             // https://github.com/rust-lang/rust/issues/53667
             if unified_section.should_be_measured() {
-                let data = pe_section_data(pe_binary, &section);
                 // Here, perform the TPM log event in ASCII.
-                // Check if we measured anything.
-                // Increment `measurements` if so.
+                if let Some(data) = pe_section_data(pe_binary, &section) {
+                    if tpm_log_event_ascii(boot_services, TPM_PCR_INDEX_KERNEL_IMAGE, data, section_name)? {
+                        measurements += 1;
+                    }
+                }
             }
         }
     }
@@ -32,7 +38,7 @@ pub unsafe fn measure_image(runtime_services: &RuntimeServices,
             cstr16!("StubPcrKernelImage"),
             &SD_LOADER,
             VariableAttributes::from_bits_truncate(0x0),
-            &TPM_PCR_INDEX_KERNEL_IMAGE.to_le_bytes()
+            &TPM_PCR_INDEX_KERNEL_IMAGE.0.to_le_bytes()
         );
     }
 

--- a/rust/stub/src/measure.rs
+++ b/rust/stub/src/measure.rs
@@ -1,0 +1,40 @@
+use uefi::{prelude::RuntimeServices, table::runtime::VariableAttributes, cstr16};
+
+use crate::{uefi_helpers::{PeInMemory, SD_LOADER}, pe_section::pe_section_data, unified_sections::UnifiedSection};
+
+const TPM_PCR_INDEX_KERNEL_IMAGE: u8 = 11;
+
+pub unsafe fn measure_image(runtime_services: &RuntimeServices,
+    image: PeInMemory) -> uefi::Result<u32> {
+    let pe_binary = unsafe { image.as_slice() };
+    let pe = goblin::pe::PE::parse(pe_binary)
+        .map_err(|err| uefi::Status::LOAD_ERROR)?;
+
+    let mut measurements = 0;
+    for section in pe.sections {
+        let section_name = section.name().map_err(|err| uefi::Status::UNSUPPORTED)?;
+        if let Ok(unified_section) = UnifiedSection::try_from(section_name) {
+            // UNSTABLE: && in the previous if is an unstable feature
+            // https://github.com/rust-lang/rust/issues/53667
+            if unified_section.should_be_measured() {
+                let data = pe_section_data(pe_binary, &section);
+                // Here, perform the TPM log event in ASCII.
+                // Check if we measured anything.
+                // Increment `measurements` if so.
+            }
+        }
+    }
+
+    if measurements > 0 {
+        // If we did some measurements, expose a variable encoding the PCR where
+        // we have done the measurements.
+        runtime_services.set_variable(
+            cstr16!("StubPcrKernelImage"),
+            &SD_LOADER,
+            VariableAttributes::from_bits_truncate(0x0),
+            &TPM_PCR_INDEX_KERNEL_IMAGE.to_le_bytes()
+        );
+    }
+
+    Ok(measurements)
+}

--- a/rust/stub/src/part_discovery.rs
+++ b/rust/stub/src/part_discovery.rs
@@ -8,10 +8,10 @@ pub fn disk_get_part_uuid(boot_services: &BootServices, disk_handle: Handle) -> 
             continue;
         }
 
-        // FIXME: is that enough? shouldn't we map _err correctly?
-        let hd_path: &HardDrive = node.try_into().map_err(|_err| uefi::Status::UNSUPPORTED)?;
-        if let PartitionSignature::Guid(guid) = hd_path.partition_signature() {
-            return Ok(guid);
+        if let Ok(hd_path) = <&HardDrive>::try_from(node) {
+            if let PartitionSignature::Guid(guid) = hd_path.partition_signature() {
+                return Ok(guid);
+            }
         }
     }
 

--- a/rust/stub/src/part_discovery.rs
+++ b/rust/stub/src/part_discovery.rs
@@ -1,5 +1,18 @@
-use uefi::{Result, Handle, CString16};
+use uefi::{Result, Handle, prelude::BootServices, proto::device_path::{DevicePath, media::{HardDrive, PartitionSignature}, DeviceType, DeviceSubType}, Guid};
 
-pub fn disk_get_part_uuid(disk_handle: Handle) -> Result<CString16> {
+pub fn disk_get_part_uuid(boot_services: &BootServices, disk_handle: Handle) -> Result<Guid> {
+    let dp = boot_services.open_protocol_exclusive::<DevicePath>(disk_handle)?;
 
+    for node in dp.node_iter() {
+        if node.device_type() != DeviceType::MEDIA || node.sub_type() != DeviceSubType::MEDIA_HARD_DRIVE {
+            continue;
+        }
+
+        let hd_path: &HardDrive = node.try_into().map_err(|err| uefi::Status::UNSUPPORTED)?;
+        if let PartitionSignature::Guid(guid) = hd_path.partition_signature() {
+            return Ok(guid);
+        }
+    }
+
+    Err(uefi::Status::UNSUPPORTED.into())
 }

--- a/rust/stub/src/part_discovery.rs
+++ b/rust/stub/src/part_discovery.rs
@@ -1,0 +1,5 @@
+use uefi::{Result, Handle, CString16};
+
+pub fn disk_get_part_uuid(disk_handle: Handle) -> Result<CString16> {
+
+}

--- a/rust/stub/src/part_discovery.rs
+++ b/rust/stub/src/part_discovery.rs
@@ -8,7 +8,8 @@ pub fn disk_get_part_uuid(boot_services: &BootServices, disk_handle: Handle) -> 
             continue;
         }
 
-        let hd_path: &HardDrive = node.try_into().map_err(|err| uefi::Status::UNSUPPORTED)?;
+        // FIXME: is that enough? shouldn't we map _err correctly?
+        let hd_path: &HardDrive = node.try_into().map_err(|_err| uefi::Status::UNSUPPORTED)?;
         if let PartitionSignature::Guid(guid) = hd_path.partition_signature() {
             return Ok(guid);
         }

--- a/rust/stub/src/pe_section.rs
+++ b/rust/stub/src/pe_section.rs
@@ -5,8 +5,21 @@
 #![allow(clippy::bind_instead_of_map)]
 
 use alloc::{borrow::ToOwned, string::String};
+use goblin::pe::section_table::SectionTable;
 
-/// Extracts the data of a section of a loaded PE file.
+/// Extracts the data of a section in a loaded PE file
+/// based on the section table.
+pub fn pe_section_data<'a>(pe_data: &'a [u8], section: &SectionTable) -> Option<&'a [u8]> {
+    let section_start: usize = section.virtual_address.try_into().ok()?;
+
+    assert!(section.virtual_size <= section.size_of_raw_data);
+    let section_end: usize = section_start + usize::try_from(section.virtual_size).ok()?;
+
+    Some(&pe_data[section_start..section_end])
+}
+
+/// Extracts the data of a section of a loaded PE file
+/// based on the section name.
 pub fn pe_section<'a>(pe_data: &'a [u8], section_name: &str) -> Option<&'a [u8]> {
     let pe_binary = goblin::pe::PE::parse(pe_data).ok()?;
 
@@ -14,14 +27,7 @@ pub fn pe_section<'a>(pe_data: &'a [u8], section_name: &str) -> Option<&'a [u8]>
         .sections
         .iter()
         .find(|s| s.name().map(|n| n == section_name).unwrap_or(false))
-        .and_then(|s| {
-            let section_start: usize = s.virtual_address.try_into().ok()?;
-
-            assert!(s.virtual_size <= s.size_of_raw_data);
-            let section_end: usize = section_start + usize::try_from(s.virtual_size).ok()?;
-
-            Some(&pe_data[section_start..section_end])
-        })
+        .and_then(|s| pe_section_data(pe_data, s))
 }
 
 /// Extracts the data of a section of a loaded PE image and returns it as a string.

--- a/rust/stub/src/tpm.rs
+++ b/rust/stub/src/tpm.rs
@@ -36,7 +36,7 @@ fn open_capable_tpm1(boot_services: &BootServices) -> uefi::Result<ScopedProtoco
     Ok(tpm_protocol)
 }
 
-fn tpm_available(boot_services: &BootServices) -> bool {
+pub fn tpm_available(boot_services: &BootServices) -> bool {
     open_capable_tpm2(boot_services).is_ok() || open_capable_tpm1(boot_services).is_ok()
 }
 

--- a/rust/stub/src/tpm.rs
+++ b/rust/stub/src/tpm.rs
@@ -1,0 +1,68 @@
+use uefi::{prelude::BootServices, table::{runtime::VariableAttributes, boot::ScopedProtocol}, cstr16, CStr16, proto::tcg::{v1, v2::{Tcg, PcrEventInputs, HashLogExtendEventFlags}, EventType, PcrIndex}};
+
+fn open_capable_tpm2(boot_services: &BootServices) -> uefi::Result<ScopedProtocol<Tcg>> {
+    let tpm_handle = boot_services.get_handle_for_protocol::<Tcg>()?;
+    let mut tpm_protocol = boot_services.open_protocol_exclusive::<Tcg>(tpm_handle)?;
+
+    let capabilities = tpm_protocol.get_capability()?;
+
+    /*
+     * Here's systemd-stub perform a cast to EFI_TCG_BOOT_SERVICE_CAPABILITY
+     * indicating there could be some quirks to workaround.
+     * It should probably go to uefi-rs?
+    if capabilities.structure_version.major == 1 && capabilities.structure_version.minor == 0 {
+
+    }*/
+
+    if !capabilities.tpm_present() {
+        return Err(uefi::Status::UNSUPPORTED.into());
+    }
+
+    Ok(tpm_protocol)
+}
+
+fn open_capable_tpm1(boot_services: &BootServices) -> uefi::Result<ScopedProtocol<v1::Tcg>> {
+    let tpm_handle = boot_services.get_handle_for_protocol::<v1::Tcg>()?;
+    let mut tpm_protocol = boot_services.open_protocol_exclusive::<v1::Tcg>(tpm_handle)?;
+
+    let status_check = tpm_protocol.status_check()?;
+
+    if status_check.protocol_capability.tpm_deactivated() || !status_check.protocol_capability.tpm_present() {
+        return Err(uefi::Status::UNSUPPORTED.into());
+    }
+
+    Ok(tpm_protocol)
+}
+
+fn tpm_available(boot_services: &BootServices) -> bool {
+    open_capable_tpm2(boot_services).is_ok() || open_capable_tpm1(boot_services).is_ok()
+}
+
+/// Log an event in the TPM with `buffer` as data.
+/// Returns a boolean whether the measurement has been done or not in case of success.
+pub fn tpm_log_event_ascii(boot_services: &BootServices,
+    pcr_index: PcrIndex, buffer: &[u8], description: &str) -> uefi::Result<bool> {
+    if pcr_index.0 == u32::MAX {
+        return Ok(false);
+    }
+
+    if let Ok(tpm2) = open_capable_tpm2(boot_services) {
+        let mut event_buffer = vec![0; 100];
+        let event = PcrEventInputs::new_in_buffer(&mut event_buffer, pcr_index, EventType::IPL, description.as_bytes())?;
+        // FIXME: what do we want as flags here?
+        tpm2.hash_log_extend_event(Default::default(), buffer, event);
+    } else if let Ok(tpm1) = open_capable_tpm1(boot_services) {
+        let mut event_buffer = vec![0; 100];
+        let digest;
+        // FIXME: sha1
+        let event = v1::PcrEvent::new_in_buffer(&mut event_buffer, pcr_index,
+            EventType::IPL,
+            digest,
+            description.as_bytes())?;
+
+        tpm1.hash_log_extend_event(event, Some(buffer))?;
+    }
+
+    Ok(true)
+}
+

--- a/rust/stub/src/tpm.rs
+++ b/rust/stub/src/tpm.rs
@@ -1,6 +1,6 @@
 use uefi::{prelude::BootServices, table::boot::ScopedProtocol, proto::tcg::{v1::{self, Sha1Digest}, v2, EventType, PcrIndex}};
 use core::mem::{self, MaybeUninit};
-use alloc::{vec, vec::Vec};
+use alloc::vec;
 
 fn open_capable_tpm2(boot_services: &BootServices) -> uefi::Result<ScopedProtocol<v2::Tcg>> {
     let tpm_handle = boot_services.get_handle_for_protocol::<v2::Tcg>()?;

--- a/rust/stub/src/uefi_helpers.rs
+++ b/rust/stub/src/uefi_helpers.rs
@@ -168,7 +168,7 @@ pub fn export_efi_variables(system_table: &SystemTable<Boot>) -> Result<()> {
     let _ = runtime_services.set_variable(
         cstr16!("StubFeatures"),
         &SD_LOADER,
-        VariableAttributes::from_bits_truncate(0x0),
+        default_attributes,
         &stub_features.bits().to_le_bytes()
     );
 

--- a/rust/stub/src/uefi_helpers.rs
+++ b/rust/stub/src/uefi_helpers.rs
@@ -3,16 +3,26 @@ use core::ffi::c_void;
 use alloc::format;
 use alloc::string::ToString;
 use alloc::vec::Vec;
+use uefi::Guid;
 use uefi::{
     prelude::{BootServices, RuntimeServices},
     proto::{loaded_image::LoadedImage, media::file::RegularFile, device_path::text::{DevicePathToText, DisplayOnly, AllowShortcuts}},
     Result, table::{runtime::{VariableVendor, VariableAttributes}, SystemTable, Boot}, CStr16, cstr16,
 };
 
-use crate::{part_discovery::disk_get_part_uuid};
+use crate::part_discovery::disk_get_part_uuid;
 
-// systemd's GUID
-const SD_LOADER: VariableVendor = "";
+// systemd loader's GUID
+// != systemd's GUID
+// FIXME: please fix me, I hate UEFI.
+// https://github.com/systemd/systemd/blob/main/src/boot/efi/util.h#L114-L121
+const SD_LOADER: VariableVendor = VariableVendor(Guid::from_values(
+        0x4a67b082,
+        0x0a4c,
+        0x41cf,
+        u16::from_le_bytes([0xb6, 0xC7]),
+        u64::from_le_bytes([0xb6, 0xc7, 0x44, 0x0b, 0x29, 0xbb, 0x8c, 0x4f])
+    ));
 // const STUB_FEATURES: ???
 
 pub fn ensure_efi_variable<'a, F>(runtime_services: &RuntimeServices,

--- a/rust/stub/src/uefi_helpers.rs
+++ b/rust/stub/src/uefi_helpers.rs
@@ -49,7 +49,7 @@ pub fn export_efi_variables(system_table: &SystemTable<Boot>) -> Result<()> {
         &SD_LOADER,
         VariableAttributes::from_bits_truncate(0x0),
         // FIXME: eeh, can we have CString16 -> &[u8] ?
-        || disk_get_part_uuid(loaded_image.device()).map(|c| c.to_string().as_bytes())
+        || disk_get_part_uuid(&boot_services, loaded_image.device()).map(|c| c.to_string().as_bytes())
     );
     // LoaderImageIdentifier
     let _ = ensure_efi_variable(runtime_services,

--- a/rust/stub/src/unified_sections.rs
+++ b/rust/stub/src/unified_sections.rs
@@ -1,0 +1,42 @@
+/// List of PE sections that have a special meaning with respect to
+/// UKI specification.
+/// This is the canonical order in which they are measured into TPM
+/// PCR 11.
+/// !!! DO NOT REORDER !!!
+pub enum UnifiedSection {
+    Linux,
+    OsRel,
+    CmdLine,
+    Initrd,
+    Splash,
+    DTB,
+    PcrSig,
+    PcrPkey
+}
+
+impl TryFrom<&str> for UnifiedSection {
+    type Error = uefi::Error;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(match value {
+            ".linux" => Self::Linux,
+            ".osrel" => Self::OsRel,
+            ".cmdline" => Self::CmdLine,
+            ".initrd" => Self::Initrd,
+            ".splash" => Self::Splash,
+            ".dtb" => Self::DTB,
+            ".pcrsig" => Self::PcrSig,
+            ".pcrpkey" => Self::PcrPkey,
+            _ => return Err(uefi::Status::INVALID_PARAMETER.into())
+        })
+    }
+}
+
+impl UnifiedSection {
+    /// Whether this section should be measured into TPM.
+    pub fn should_be_measured(&self) -> bool {
+        match self {
+            UnifiedSection::PcrSig => false,
+            _ => true
+        }
+    }
+}


### PR DESCRIPTION
Depends on #167 #166.

This adds CPIO packing, I am very unsatisfied about having to bring `acid_io`, but I didn't want to make the code more unreadable, this is CPIO stuff, so it's a bit annoying.

Some alignments are missing for the size checks. I want to add proper unit testing to this file.

- `pack_prefix` is missing (`mkdir -p` equivalent)
- `pack_trailer` is abusing pack_one, I need to rework this a bit

I want to think if I want to get a CString16 or not. I think yes because they will come from UEFI APIs.

With this, we should be able to read from drop-in directories, load CPIO archives and combine them as initrds for sysexts (+ measurements).