### PR TITLE
chore: sync our crates version to latest tag

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -215,6 +215,7 @@
                 pkgs.qemu
                 pkgs.nixpkgs-fmt
                 pkgs.statix
+                pkgs.cargo-release
               ];
 
             inputsFrom = [

--- a/rust/stub/Cargo.lock
+++ b/rust/stub/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "lanzaboote_stub"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bitflags 2.2.1",
  "goblin",

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lanzaboote_stub"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 publish = false
 # For UEFI target

--- a/rust/tool/Cargo.lock
+++ b/rust/tool/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "lanzaboote_tool"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/rust/tool/Cargo.toml
+++ b/rust/tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lanzaboote_tool"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
We didn't do it, now we do it and we have the nifty `cargo-release`, some good automation could be done for cutting releases, etc.