### PR TITLE
Cleanup flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Lanzaboot Secure Boot Madness";
+  description = "Lanzaboote: Secure Boot for NixOS";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";

--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,7 @@
             src = ./rust/tool;
             extraArgs = {
               TEST_SYSTEMD = pkgs.systemd;
-              checkInputs = with pkgs; [
+              nativeCheckInputs = with pkgs; [
                 binutils-unwrapped
                 sbsigntool
               ];


### PR DESCRIPTION
Add a proper description to flake.

Use nativeCheckInputs instead of checkInputs because it is more
semantically correct even if checkInputs works with Crane.