### PR TITLE
Revert "deps: update to uefi-rs 0.21.0"

### DIFF
--- a/rust/stub/Cargo.lock
+++ b/rust/stub/Cargo.lock
@@ -10,9 +10,15 @@ checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
-version = "2.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
 
 [[package]]
 name = "block-buffer"
@@ -28,12 +34,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cpufeatures"
@@ -55,23 +55,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -102,7 +89,7 @@ dependencies = [
 name = "lanzaboote_stub"
 version = "0.3.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.2.1",
  "goblin",
  "log",
  "sha1_smol",
@@ -113,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "log"
@@ -134,9 +121,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -158,25 +145,16 @@ checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
 ]
 
 [[package]]
@@ -196,14 +174,8 @@ checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "sha1_smol"
@@ -234,17 +206,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,58 +222,38 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.21.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b568c22d9ed54fb8695eff4252975063a3fa20281049df911d0237b44b86b6a"
+checksum = "ab39d5e7740f21ed4c46d6659f31038bbe3fe7a8be1f702d8a984348837c43b1"
 dependencies = [
- "bitflags",
- "derive_more",
+ "bitflags 1.3.2",
  "log",
  "ptr_meta",
  "ucs2",
  "uefi-macros",
- "uefi-raw",
- "uguid",
 ]
 
 [[package]]
 name = "uefi-macros"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023d94ef8e135d068b9a3bd94614ef2610b2b0419ade0a9d8f3501fa9cd08e95"
+checksum = "e0caeb0e7b31b9f1f347e541106be10aa8c66c76fa722a3298a4cd21433fabd4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
-]
-
-[[package]]
-name = "uefi-raw"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5b1c8cd8a8a201bcc0d132f8367f5cb7c38c99a5debe304392d379963776d5"
-dependencies = [
- "bitflags",
- "ptr_meta",
- "uguid",
+ "syn",
 ]
 
 [[package]]
 name = "uefi-services"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de55164b5fc3eddb8619add9fa14d91321bb337507e1f0d065a992060f1ccafc"
+checksum = "42d8ffbcc532083312224b4540737c1102ede6a81360fa9320a60deff329a3a1"
 dependencies = [
  "cfg-if",
  "log",
  "uefi",
 ]
-
-[[package]]
-name = "uguid"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594cc87e268a7b43d625d46c63cf1605d0e61bf66e4b1cd58c058ec0191e1f81"
 
 [[package]]
 name = "unicode-ident"

--- a/rust/stub/Cargo.toml
+++ b/rust/stub/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 rust-version = "1.68"
 
 [dependencies]
-uefi = { version = "0.21.0", default-features = false, features = [ "alloc", "global_allocator" ] }
-uefi-services = { version = "0.18.0", default-features = false, features = [ "panic_handler", "logger" ] }
+uefi = { version = "0.20.0", default-features = false, features = [ "alloc", "global_allocator" ] }
+uefi-services = { version = "0.17.0", default-features = false, features = [ "panic_handler", "logger" ] }
 goblin = { version = "0.6.1", default-features = false, features = [ "pe64", "alloc" ]}
 bitflags = "2.3.1"
 

--- a/rust/stub/src/efivars.rs
+++ b/rust/stub/src/efivars.rs
@@ -142,7 +142,7 @@ where
         runtime_services.set_variable(name, vendor, attributes, &get_fallback_value()?)?;
     }
 
-    Ok(())
+    uefi::Status::SUCCESS.into()
 }
 
 /// Exports systemd-stub style EFI variables

--- a/rust/stub/src/linux_loader.rs
+++ b/rust/stub/src/linux_loader.rs
@@ -122,6 +122,7 @@ impl InitrdLoader {
         let mut proto = Box::pin(LoadFile2Protocol {
             load_file: raw_load_file,
             initrd_data,
+            _no_send_or_sync: Default::default(),
         });
 
         // Linux finds the right handle by looking for something that

--- a/rust/stub/src/main.rs
+++ b/rust/stub/src/main.rs
@@ -21,9 +21,19 @@ use pe_loader::Image;
 use pe_section::{pe_section, pe_section_as_string};
 use sha2::{Digest, Sha256};
 use tpm::tpm_available;
-use uefi::{prelude::*, proto::loaded_image::LoadedImage, CStr16, CString16, Result};
+use uefi::{
+    prelude::*,
+    proto::{
+        loaded_image::LoadedImage,
+        media::file::{File, FileAttribute, FileMode},
+    },
+    CStr16, CString16, Result,
+};
 
-use crate::{linux_loader::InitrdLoader, uefi_helpers::booted_image_file};
+use crate::{
+    linux_loader::InitrdLoader,
+    uefi_helpers::{booted_image_file, read_all},
+};
 
 type Hash = sha2::digest::Output<Sha256>;
 
@@ -117,7 +127,7 @@ fn boot_linux_unchecked(
     let status = unsafe { kernel.start(handle, &system_table, kernel_cmdline) };
 
     initrd_loader.uninstall(system_table.boot_services())?;
-    status.to_result()
+    status.into()
 }
 
 /// Boot the Linux kernel via the UEFI PE loader.
@@ -163,7 +173,7 @@ fn boot_linux_uefi(
         .status();
 
     initrd_loader.uninstall(system_table.boot_services())?;
-    status.to_result()
+    status.into()
 }
 
 #[entry]
@@ -193,13 +203,33 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
             .boot_services()
             .get_image_file_system(handle)
             .expect("Failed to get file system handle");
+        let mut root = file_system
+            .open_volume()
+            .expect("Failed to find ESP root directory");
 
-        kernel_data = file_system
-            .read(&*config.kernel_filename)
-            .expect("Failed to read kernel file into memory");
-        initrd_data = file_system
-            .read(&*config.initrd_filename)
-            .expect("Failed to read initrd file into memory");
+        let mut kernel_file = root
+            .open(
+                &config.kernel_filename,
+                FileMode::Read,
+                FileAttribute::empty(),
+            )
+            .expect("Failed to open kernel file for reading")
+            .into_regular_file()
+            .expect("Kernel is not a regular file");
+
+        kernel_data = read_all(&mut kernel_file).expect("Failed to read kernel file into memory");
+
+        let mut initrd_file = root
+            .open(
+                &config.initrd_filename,
+                FileMode::Read,
+                FileAttribute::empty(),
+            )
+            .expect("Failed to open initrd for reading")
+            .into_regular_file()
+            .expect("Initrd is not a regular file");
+
+        initrd_data = read_all(&mut initrd_file).expect("Failed to read kernel file into memory");
     }
 
     let is_kernel_hash_correct = Sha256::digest(&kernel_data) == config.kernel_hash;

--- a/rust/stub/src/uefi_helpers.rs
+++ b/rust/stub/src/uefi_helpers.rs
@@ -1,6 +1,29 @@
 use core::ffi::c_void;
 
-use uefi::{prelude::BootServices, proto::loaded_image::LoadedImage, Result};
+use alloc::vec::Vec;
+use uefi::{
+    prelude::BootServices,
+    proto::{loaded_image::LoadedImage, media::file::RegularFile},
+    Result,
+};
+
+/// Read the whole file into a vector.
+pub fn read_all(file: &mut RegularFile) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+
+    loop {
+        let mut chunk = [0; 512];
+        let read_bytes = file.read(&mut chunk).map_err(|e| e.status())?;
+
+        if read_bytes == 0 {
+            break;
+        }
+
+        buf.extend_from_slice(&chunk[0..read_bytes]);
+    }
+
+    Ok(buf)
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct PeInMemory {


### PR DESCRIPTION
This reverts commit c96299ea46feadc77d7ded2cd582d174e86e2a67.

Due to https://github.com/rust-osdev/uefi-rs/issues/825.