### PR TITLE
Fix eval when aliases are disabled

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,8 +63,8 @@
             inherit system;
             crossSystem = {
               # linuxArch is wrong here, it will yield arm64 instead of aarch64.
-              config = "${pkgs.hostPlatform.qemuArch}-windows";
-              rustc.config = "${pkgs.hostPlatform.qemuArch}-unknown-uefi";
+              config = "${pkgs.stdenv.hostPlatform.qemuArch}-windows";
+              rustc.config = "${pkgs.stdenv.hostPlatform.qemuArch}-unknown-uefi";
               libc = null;
               useLLVM = true;
             };


### PR DESCRIPTION
```
       error: attribute 'hostPlatform' missing

       at /nix/store/k7h8k8whqw64rmsg6yhkmmdc82lkczc6-source/flake.nix:66:27:

           65|               # linuxArch is wrong here, it will yield arm64 instead of aarch64.
           66|               config = "${pkgs.hostPlatform.qemuArch}-windows";
             |                           ^
           67|               rustc.config = "${pkgs.hostPlatform.qemuArch}-unknown-uefi";
       Did you mean rustPlatform?
```