### PR TITLE
update QUICK_START.md bootspec

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -98,27 +98,6 @@ This takes a couple of seconds. When it is done, your Secure Boot keys
 are located in `/etc/secureboot`. `sbctl` sets the permissions of the
 secret key so that only root can read it.
 
-### Switching to bootspec
-
-`lzbt` currently doesn't handle
-non-[bootspec](https://github.com/grahamc/rfcs/blob/bootspec/rfcs/0125-bootspec.md)
-generations well
-([#55](https://github.com/nix-community/lanzaboote/issues/55)). As
-such, we need to switch to bootspec and get rid of all previous
-generations before we can continue.
-
-Bootspec is currently available as preview in nixpkgs unstable. To
-enable bootspec, set `boot.bootspec.enable = true;` in your system
-configuration, rebuild and reboot.
-
-When everything is working, you can garbage collect your old
-non-bootspec generations: `nix-collect-garbage -d`.
-
-🔪 **Sharp edge:** 🔪 This will leave old boot entries lying around in
-the ESP. `systemd-boot` will display these during boot. This can be
-confusing during boot. **After you made a backup of your ESP**, you
-may delete these entries in `/boot/loader/entries`.
-
 ### Configuring NixOS (with [`niv`](https://github.com/nmattia/niv))
 
 Add `lanzaboote` as a dependency of your niv project and track a stable release tag (https://github.com/nix-community/lanzaboote/releases).
@@ -141,9 +120,6 @@ let
 in
 {
   imports = [ lanzaboote.nixosModules.lanzaboote ];
-  # This should already be here from switching to bootspec earlier.
-  # It's not required anymore, but also doesn't do any harm.
-  boot.bootspec.enable = true;
 
   environment.systemPackages = [
     # For debugging and troubleshooting Secure Boot.
@@ -195,9 +171,6 @@ Boot stack.
           lanzaboote.nixosModules.lanzaboote
 
           ({ pkgs, lib, ... }: {
-            # This should already be here from switching to bootspec earlier.
-            # It's not required anymore, but also doesn't do any harm.
-            boot.bootspec.enable = true;
 
             environment.systemPackages = [
               # For debugging and troubleshooting Secure Boot.


### PR DESCRIPTION
Since this is the default now there should probably be a mention that you can skip this with a somewhat recent system. 

Note: There should probably be a version number stated of the version that made bootspec on by default but I don't know which version this was so :shrug: 