### PR TITLE
feat: experiment lanzaboote with partial deduplication with no custom stub

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,16 +77,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685071405,
-        "narHash": "sha256-qENk2wk0Zli0zeLDKMNcs8CfhPIHhtRQgPamlFUM/xw=",
-        "owner": "NixOS",
+        "lastModified": 1687136445,
+        "narHash": "sha256-TPxFaSBVmT0wb8ZBQW9Ao0HeTWLULA/dYFeWt6Af8EA=",
+        "owner": "RaitoBezarius",
         "repo": "nixpkgs",
-        "rev": "794a24afefde85c3e9b533443c4c73cd871f9e3a",
+        "rev": "2d3fb0263f0de88235f0634289949362db5f6821",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable-small",
+        "owner": "RaitoBezarius",
+        "ref": "sd-addon-for-sb",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Lanzaboote: Secure Boot for NixOS";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+    nixpkgs.url = "github:RaitoBezarius/nixpkgs/sd-addon-for-sb";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";


### PR DESCRIPTION
This is an attempt to reproduce lanzaboote feats without the lanzastub, albeit, with a partial deduplication as `.linux` cannot be made an addon for now ; it's unknown whether this is an arbitrary limitation or something else. Worst case, we can patch out this limitation, I imagine.

TODO:

- [ ] Modify `lzbt` to render Type 1 entries with `linux $stub-with-kernel-uki`, `add-on $initrd`, `add-on $cmdline`.
- [ ] Modify `lzbt` to generate `$stub-with-kernel-uki`, i.e. an UKI.
- [ ] Modify `lzbt` to generate addons with arbitrary payloads, e.g. take the existing systemd addon and objcopy the sections?
- [ ] Modify `lzbt` to generate `$initrd`, `$cmdline`
- [ ] Modify `lzbt` to support GC in this new context