### PR TITLE
flake: offer nix-community cache as a suggested substituter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,11 @@
 {
+  nixConfig.extra-substituters = [
+    "https://nix-community.cachix.org"
+  ];
+  nixConfig.extra-trusted-public-keys = [
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+  ];
+
   description = "Lanzaboote: Secure Boot for NixOS";
 
   inputs = {


### PR DESCRIPTION
As we use Hercules CI with nix-community builder, our CI sends the stuff there all the time.

Now, let's make everyone benefit from it.