### PR TITLE
Revert "docs: suggest to track released versions rather than master "

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -103,7 +103,7 @@ secret key so that only root can read it.
 Add `lanzaboote` as a dependency of your niv project and track a stable release tag (https://github.com/nix-community/lanzaboote/releases).
 
 ```console
-$ niv add nix-community/lanzaboote -r v0.3.0 -v 0.3.0
+$ niv add nix-community/lanzaboote -r v0.2.0 -v 0.2.0
 Adding package lanzaboote
   Writing new sources file
 Done: Adding package lanzaboote
@@ -149,7 +149,7 @@ Boot stack.
   description = "A SecureBoot-enabled NixOS configurations";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable/0.3.0";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     lanzaboote = {
       url = "github:nix-community/lanzaboote";


### PR DESCRIPTION
Reverts nix-community/lanzaboote#207 because it tells users to use a 0.3 branch on nixpkgs