### PR TITLE
Fix lzbt build with recent nixos-unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,9 +80,16 @@
 
           inherit (pkgs) lib;
 
-          stub = uefiPkgs.callPackage ./nix/packages/stub.nix { };
-          fatStub =
-            uefiPkgs.callPackage ./nix/packages/stub.nix { fatVariant = true; };
+          stub = uefiPkgs.callPackage ./nix/packages/stub.nix {
+            # cargo-auditable fails to build with: could not execute process .... No such file or directory (os error 2)
+            rustPlatform = uefiPkgs.makeRustPlatform {
+              inherit (uefiPkgs.buildPackages) rustc;
+              cargo = uefiPkgs.buildPackages.cargo.override {
+                auditable = false;
+              };
+            };
+          };
+          fatStub = stub.override { fatVariant = true; };
           tool = pkgs.callPackage ./nix/packages/tool.nix { };
 
           wrappedTool = pkgs.runCommand "lzbt"


### PR DESCRIPTION
This fixes the following error:
....
cargo-auditable>    Doc-tests auditable-extract
cargo-auditable> error: doctest failed, to rerun pass `-p auditable-extract --doc`
cargo-auditable>
cargo-auditable> Caused by:
cargo-auditable>   could not execute process `rustdoc --edition=2018 --crate-type lib --crate-name auditable_extract --test /build/source/auditable-extract/src/lib.rs --target x86_64-unknown-linux-gnu -L dependency=/build/source/target/x86_64-unknown-linux-gnu/release/deps -L dependency=/build/source/target/release/deps --test-args --test-threads=96 --extern auditable_extract=/build/source/target/x86_64-unknown-linux-gnu/release/deps/libauditable_extract-dd1904617e4b78db.rlib --extern binfarce=/build/source/target/x86_64-unknown-linux-gnu/release/deps/libbinfarce-2ba09d21aed0de1a.rlib -C embed-bitcode=no --error-format human` (never executed)
cargo-auditable>
cargo-auditable> Caused by:
cargo-auditable>   No such file or directory (os error 2)


Tested on a machine by rebuilding with this branch as flake input and follows on the latest things of everything.