### PR TITLE
flake: remove nixConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,4 @@
 {
-  nixConfig.extra-substituters = [
-    "https://nix-community.cachix.org"
-  ];
-  nixConfig.extra-trusted-public-keys = [
-    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-  ];
-
   description = "Secure Boot for NixOS";
 
   inputs = {


### PR DESCRIPTION
nixConfig is not a nice abstraction because it imperatively changes your system. However this also does not work correctly without extra changes to your system (i.e. your NixOS configuration). Thus it is removed.