### PR TITLE
Netboot support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -199,6 +199,7 @@
           checks =
             let
               nixosLib = import (pkgs.path + "/nixos/lib") { };
+              evalConfig = import (pkgs.path + "/nixos/lib/eval-config.nix");
               runTest = module: nixosLib.runTest {
                 imports = [ module ];
                 hostPkgs = pkgs;
@@ -211,7 +212,7 @@
               toolFmt = toolCrane.rustfmt;
               stubFmt = stubCrane.rustfmt;
             } // (import ./nix/tests/lanzaboote.nix {
-              inherit pkgs;
+              inherit pkgs evalConfig;
               lanzabooteModule = self.nixosModules.lanzaboote;
             }) // (import ./nix/tests/stub.nix {
               inherit pkgs runTest;

--- a/rust/tool/shared/src/esp.rs
+++ b/rust/tool/shared/src/esp.rs
@@ -16,3 +16,109 @@ pub trait EspPaths<const N: usize> {
     /// Returns the path containing Linux EFI binaries
     fn linux_path(&self) -> &Path;
 }
+
+pub struct BuildEspPaths {
+    root_path: PathBuf
+}
+
+impl EspPaths<0> for BuildEspPaths {
+    fn new(esp: impl AsRef<Path>) -> Self {
+        BuildEspPaths {
+            root_path: esp.as_ref().to_path_buf()
+        }
+    }
+
+    fn iter(&self) -> std::array::IntoIter<&PathBuf, 0> {
+        [].into_iter()
+    }
+
+    fn nixos_path(&self) -> &Path {
+        &self.root_path
+    }
+
+    fn linux_path(&self) -> &Path {
+        &self.root_path
+    }
+}
+
+/// Paths to the boot files of a specific generation.
+pub struct EspGenerationPaths {
+    pub kernel: PathBuf,
+    pub initrd: PathBuf,
+    pub lanzaboote_image: PathBuf,
+}
+
+impl EspGenerationPaths {
+    pub fn new<const N: usize, P: EspPaths<N>>(
+        esp_paths: &P,
+        generation: &Generation,
+    ) -> Result<Self> {
+        let bootspec = &generation.spec.bootspec.bootspec;
+
+        Ok(Self {
+            kernel: esp_paths
+                .nixos_path()
+                .join(nixos_path(&bootspec.kernel, "bzImage")?),
+            initrd: esp_paths.nixos_path().join(nixos_path(
+                bootspec
+                    .initrd
+                    .as_ref()
+                    .context("Lanzaboote does not support missing initrd yet")?,
+                "initrd",
+            )?),
+            lanzaboote_image: esp_paths.linux_path().join(generation_path(generation)),
+        })
+    }
+
+    /// Return the used file paths to store as garbage collection roots.
+    pub fn to_iter(&self) -> IntoIter<&PathBuf, 3> {
+        [&self.kernel, &self.initrd, &self.lanzaboote_image].into_iter()
+    }
+}
+
+fn nixos_path(path: impl AsRef<Path>, name: &str) -> Result<PathBuf> {
+    let resolved = path
+        .as_ref()
+        .read_link()
+        .unwrap_or_else(|_| path.as_ref().into());
+
+    let parent_final_component = resolved
+        .parent()
+        .and_then(|x| x.file_name())
+        .and_then(|x| x.to_str())
+        .with_context(|| format!("Failed to extract final component from: {:?}", resolved))?;
+
+    let nixos_filename = format!("{}-{}.efi", parent_final_component, name);
+
+    Ok(PathBuf::from(nixos_filename))
+}
+
+fn generation_path(generation: &Generation) -> PathBuf {
+    if let Some(specialisation_name) = generation.is_specialised() {
+        PathBuf::from(format!(
+            "nixos-generation-{}-specialisation-{}.efi",
+            generation, specialisation_name
+        ))
+    } else {
+        PathBuf::from(format!("nixos-generation-{}.efi", generation))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nixos_path_creates_correct_filename_from_nix_store_path() -> Result<()> {
+        let path =
+            Path::new("/nix/store/xqplddjjjy1lhzyzbcv4dza11ccpcfds-initrd-linux-6.1.1/initrd");
+
+        let generated_filename = nixos_path(path, "initrd")?;
+
+        let expected_filename =
+            PathBuf::from("xqplddjjjy1lhzyzbcv4dza11ccpcfds-initrd-linux-6.1.1-initrd.efi");
+
+        assert_eq!(generated_filename, expected_filename);
+        Ok(())
+    }
+}

--- a/rust/tool/shared/src/generation.rs
+++ b/rust/tool/shared/src/generation.rs
@@ -39,6 +39,16 @@ pub struct Generation {
 }
 
 impl Generation {
+    pub fn from_toplevel(toplevel: &Path, version: u64) -> Result<Self> {
+        let link = GenerationLink {
+            version,
+            build_time: read_build_time(toplevel).ok(),
+            path: toplevel.to_path_buf()
+        };
+
+        Self::from_link(&link)
+    }
+
     pub fn from_link(link: &GenerationLink) -> Result<Self> {
         let bootspec_path = link.path.join("boot.json");
         let boot_json: BootJson = fs::read(bootspec_path)

--- a/rust/tool/shared/src/utils.rs
+++ b/rust/tool/shared/src/utils.rs
@@ -74,3 +74,13 @@ pub fn file_hash(file: &Path) -> Result<Hash> {
         format!("Failed to read file to hash: {file:?}")
     })?))
 }
+
+pub fn assemble_kernel_cmdline(init: &Path, kernel_params: Vec<String>) -> Vec<String> {
+    let init_string = String::from(
+        init.to_str()
+            .expect("Failed to convert init path to string"),
+    );
+    let mut kernel_cmdline: Vec<String> = vec![format!("init={}", init_string)];
+    kernel_cmdline.extend(kernel_params);
+    kernel_cmdline
+}

--- a/rust/tool/systemd/src/cli.rs
+++ b/rust/tool/systemd/src/cli.rs
@@ -1,11 +1,13 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, io::Write};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use tempfile::TempDir;
 
 use crate::install;
 use lanzaboote_tool::architecture::Architecture;
 use lanzaboote_tool::signature::KeyPair;
+use lanzaboote_tool::generation::{GenerationLink, Generation}, pe, os_release::OsRelease, utils::{SecureTempDirExt, assemble_kernel_cmdline}, esp::{EspGenerationPaths, BuildEspPaths, EspPaths}};
 
 /// The default log level.
 ///
@@ -27,6 +29,25 @@ pub struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     Install(InstallCommand),
+    Build(BuildCommand)
+}
+
+#[derive(Parser)]
+struct BuildCommand {
+    /// sbsign Public Key
+    #[arg(long)]
+    public_key: PathBuf,
+
+    /// sbsign Private Key
+    #[arg(long)]
+    private_key: PathBuf,
+
+    /// Override initrd
+    #[arg(long)]
+    initrd: PathBuf,
+
+    /// Generation
+    generation: PathBuf
 }
 
 #[derive(Parser)]
@@ -83,6 +104,7 @@ impl Commands {
     pub fn call(self) -> Result<()> {
         match self {
             Commands::Install(args) => install(args),
+            Commands::Build(args) => build(args),
         }
     }
 }
@@ -104,4 +126,49 @@ fn install(args: InstallCommand) -> Result<()> {
         args.generations,
     )
     .install()
+}
+
+fn build(args: BuildCommand) -> Result<()> {
+    let lanzaboote_stub =
+        PathBuf::from(std::env::var("LANZABOOTE_STUB").context("Failed to read LANZABOOTE_STUB env variable")?);
+
+    let key_pair = KeyPair::new(&args.public_key, &args.private_key);
+
+    let generation = Generation::from_toplevel(&args.generation, 1)
+        .with_context(|| format!("Failed to build generation from link: {0:?}", args.generation))?;
+    let bootspec = &generation.spec.bootspec.bootspec;
+
+    let tempdir = TempDir::new().context("Failed to create temporary directory")?;
+    let os_release = OsRelease::from_generation(&generation)
+        .context("Failed to build OsRelease from generation.")?;
+    let os_release_path = tempdir
+        .write_secure_file(os_release.to_string().as_bytes())
+        .context("Failed to write os-release file.")?;
+    let kernel_cmdline =
+        assemble_kernel_cmdline(&bootspec.init, bootspec.kernel_params.clone());
+    let esp = PathBuf::from("/");
+    let esp_paths = BuildEspPaths::new("/");
+    let esp_gen_paths = EspGenerationPaths::new(&esp_paths, &generation)?;
+
+    let lzbt_stub = pe::lanzaboote_image(
+        &tempdir,
+        &lanzaboote_stub,
+        &os_release_path,
+        &kernel_cmdline,
+        &bootspec.kernel,
+        &args.initrd,
+        &esp_gen_paths,
+        &esp
+    )?;
+
+    // Sign the stub.
+    let to = tempdir.path().join("signed-lzbt-stub.efi");
+    key_pair
+        .sign_and_copy(&lzbt_stub, &to)
+        .with_context(|| format!("Failed to copy and sign file {lzbt_stub:?} to {to:?}"))?;
+
+    // Output the stub on stdout.
+    std::io::stdout().write_all(&std::fs::read(to)?)?;
+
+    Ok(())
 }

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -23,7 +23,7 @@ use lanzaboote_tool::generation::{Generation, GenerationLink};
 use lanzaboote_tool::os_release::OsRelease;
 use lanzaboote_tool::pe;
 use lanzaboote_tool::signature::KeyPair;
-use lanzaboote_tool::utils::{file_hash, SecureTempDirExt};
+use lanzaboote_tool::utils::{file_hash, SecureTempDirExt, assemble_kernel_cmdline};
 
 pub struct Installer {
     broken_gens: BTreeSet<u64>,
@@ -451,16 +451,6 @@ pub fn append_initrd_secrets(
     }
 
     Ok(())
-}
-
-fn assemble_kernel_cmdline(init: &Path, kernel_params: Vec<String>) -> Vec<String> {
-    let init_string = String::from(
-        init.to_str()
-            .expect("Failed to convert init path to string"),
-    );
-    let mut kernel_cmdline: Vec<String> = vec![format!("init={}", init_string)];
-    kernel_cmdline.extend(kernel_params);
-    kernel_cmdline
 }
 
 /// Atomically copy a file.

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -1,6 +1,8 @@
 use log::{error, warn};
 use sha2::{Digest, Sha256};
-use uefi::{fs::FileSystem, prelude::*, CString16, Result};
+use uefi::{fs::FileSystem, proto::loaded_image::LoadedImage, prelude::*, CStr16, CString16, Result};
+use uefi::proto::network::IpAddress;
+use uefi::proto::network::pxe::{BaseCode, DhcpV4Packet};
 
 use crate::common::{boot_linux_unchecked, extract_string, get_cmdline, get_secure_boot_status};
 use linux_bootloader::pe_section::pe_section;
@@ -93,8 +95,8 @@ pub fn boot_linux(handle: Handle, mut system_table: SystemTable<Boot>) -> uefi::
 
     let secure_boot_enabled = get_secure_boot_status(system_table.runtime_services());
 
-    let kernel_data;
-    let initrd_data;
+    let mut kernel_data;
+    let mut initrd_data;
 
     {
         let file_system = system_table
@@ -103,12 +105,57 @@ pub fn boot_linux(handle: Handle, mut system_table: SystemTable<Boot>) -> uefi::
             .expect("Failed to get file system handle");
         let mut file_system = FileSystem::new(file_system);
 
-        kernel_data = file_system
-            .read(&*config.kernel_filename)
-            .expect("Failed to read kernel file into memory");
-        initrd_data = file_system
-            .read(&*config.initrd_filename)
-            .expect("Failed to read initrd file into memory");
+        if system_table.boot_services().test_protocol::<uefi::proto::media::fs::SimpleFileSystem>(filesystem_protocol_params).is_ok() {
+            let mut file_system = system_table
+                .boot_services()
+                .get_image_file_system(handle)
+                .expect("Failed to get file system handle");
+
+            kernel_data = file_system
+                .read(&*config.kernel_filename)
+                .expect("Failed to read kernel file into memory");
+            initrd_data = file_system
+                .read(&*config.initrd_filename)
+                .expect("Failed to read initrd file into memory");
+        } else {
+            let loaded_image_protocol = system_table.boot_services().open_protocol_exclusive::<LoadedImage>(system_table.boot_services().image_handle())
+                .expect("Failed to open the loaded image protocol on the currently loaded image");
+
+            let mut base_code = system_table.boot_services().open_protocol_exclusive::<BaseCode>(loaded_image_protocol.device()).unwrap();
+
+            assert!(base_code.mode().dhcp_ack_received);
+            let dhcp_ack: &DhcpV4Packet = base_code.mode().dhcp_ack.as_ref();
+            let server_ip = dhcp_ack.bootp_si_addr;
+            let server_ip = IpAddress::new_v4(server_ip);
+
+            let kernel_filename = cstr8!("./bzImage");
+            let initrd_filename = cstr8!("./initrd");
+
+            let kfile_size = base_code
+                .tftp_get_file_size(&server_ip, kernel_filename)
+                .expect("failed to query file size");
+
+            let ifile_size = base_code
+                .tftp_get_file_size(&server_ip, initrd_filename)
+                .expect("failed to query file size");
+
+            assert!(kfile_size > 0);
+            assert!(ifile_size > 0);
+
+            kernel_data = Vec::with_capacity(kfile_size as usize);
+            kernel_data.resize(kfile_size as usize, 0);
+            initrd_data = Vec::with_capacity(ifile_size as usize);
+            initrd_data.resize(ifile_size as usize, 0);
+            let klen = base_code
+                .tftp_read_file(&server_ip, kernel_filename, Some(&mut kernel_data))
+                .expect("failed to read file");
+            let ilen = base_code
+                .tftp_read_file(&server_ip, initrd_filename, Some(&mut initrd_data))
+                .expect("failed to read file");
+
+            assert!(klen > 0);
+            assert!(ilen > 0);
+        }
     }
 
     let cmdline = get_cmdline(


### PR DESCRIPTION
Summary:

- enables `lzbt build` with the systemd tool to produce one-off stubs that can be built inside of a Nix derivation
- enable the thin stub to transfer control if booted via netboot (the fat stub should work out of the box because it contains all it needs and doesn't require further FS access) reusing PXE base code protocol
- add a crude netboot test using NixOS test framework