### PR TITLE
auto-enroll: use safe auto enrollment rather than YOLO enrollment

### DIFF
--- a/nix/tests/lanzaboote/common/lanzaboote.nix
+++ b/nix/tests/lanzaboote/common/lanzaboote.nix
@@ -1,4 +1,8 @@
-{ config, pkgs, ... }: {
+{ lib, config, pkgs, ... }:
+let
+  inherit (lib) mkIf;
+in
+{
 
   virtualisation = {
     useBootLoader = true;
@@ -14,7 +18,11 @@
 
     lanzaboote = {
       enable = true;
-      enrollKeys = config.virtualisation.useSecureBoot;
+      safeAutoEnroll = mkIf (config.virtualisation.useSecureBoot) {
+        db = ../../fixtures/uefi-keys/keys/db/db.pem;
+        KEK = ../../fixtures/uefi-keys/keys/KEK/KEK.pem;
+        PK = ../../fixtures/uefi-keys/keys/PK/PK.pem;
+      };
       pkiBundle = ../../fixtures/uefi-keys;
     };
   };


### PR DESCRIPTION
This uses the systemd semantics for automatic enrollment at boot time.

For now, it is very simple, in the future, we can better use this option to push the proper auth files with names or have Type #1 entries for enrollment. :)

~~This PR relies on unreleased commits in nixpkgs for the testing framework to detect properly for EFI resets as for some reason this makes the whole thing hangs otherwise…~~

In other news, your wish has been granted @blitz !