### PR TITLE
nix/modules/uki: fix ukify build

### DIFF
--- a/nix/modules/uki.nix
+++ b/nix/modules/uki.nix
@@ -21,6 +21,7 @@ in
     let
       systemdUkify = pkgs.systemdMinimal.override {
         withEfi = true;
+        withBootloader = true;
         withUkify = true;
       };
     in


### PR DESCRIPTION
Previously, we were not on recent enough nixpkgs to see the new `withBootloader` flag which is required to build ukify.

Fixes the test infrastructure for the UKI part.