### PR TITLE
Fix eval in flakes when aliases are disabled

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,7 @@
 
       perSystem = { config, system, pkgs, ... }:
         let
-          rustTarget = "${pkgs.hostPlatform.qemuArch}-unknown-uefi";
+          rustTarget = "${pkgs.stdenv.hostPlatform.qemuArch}-unknown-uefi";
           pkgs = import nixpkgs {
             system = system;
             overlays = [


### PR DESCRIPTION
Fixes 

```
       error: attribute 'hostPlatform' missing

       at /nix/store/8hqjsxybh8fvkij104linyyp3gi3c560-source/flake.nix:82:27:

           81|         let
           82|           rustTarget = "${pkgs.hostPlatform.qemuArch}-unknown-uefi";
             |                           ^
           83|           pkgs = import nixpkgs {
       Did you mean rustPlatform?
```

regressed in #31