### PR TITLE
stub: update to latest uefi crates

### DIFF
--- a/rust/uefi/Cargo.lock
+++ b/rust/uefi/Cargo.lock
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b63e82686b4bdb0db74f18b2abbd60a0470354fb640aa69e115598d714d0a10"
+checksum = "1cb8f384905087f56c2fdf90bb7d94d24c600775b9f40424a4b80882ba399d47"
 dependencies = [
  "bitflags",
  "log",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62642516099c6441a5f41b0da8486d5fc3515a0603b0fdaea67b31600e22082e"
+checksum = "8bbf45ee102da89ef37674dd5186cd766418338457e660e7a3a1bad64d122abf"
 dependencies = [
  "bitflags",
  "ptr_meta",
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-services"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b32954ebbb4be5ebfde0df6699c2091f04e9f9c3762c65f3435dfb1a90a668"
+checksum = "f23d40df0511a2de5cadd20c9fcb2f998ac82f0c0da8a9b2817c8e8a4f0fd6fb"
 dependencies = [
  "cfg-if",
  "log",
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "uguid"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16dfbd255defbd727b3a30e8950695d2e6d045841ee250ff0f1f7ced17917f8d"
+checksum = "1ef516f0806c5f61da6aa95125d0eb2d91cc95b2df426c06bde8be657282aee5"
 
 [[package]]
 name = "unicode-ident"

--- a/rust/uefi/linux-bootloader/Cargo.toml
+++ b/rust/uefi/linux-bootloader/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nix-community/lanzaboote/"
 rust-version = "1.68"
 
 [dependencies]
-uefi = { version = "0.24.0", default-features = false, features = [ "alloc", "global_allocator" ] }
+uefi = { version = "0.25.0", default-features = false, features = [ "alloc", "global_allocator" ] }
 goblin = { version = "0.6.1", default-features = false, features = [ "pe64", "alloc" ]}
 bitflags = "2.3.3"
 

--- a/rust/uefi/linux-bootloader/src/efivars.rs
+++ b/rust/uefi/linux-bootloader/src/efivars.rs
@@ -162,7 +162,11 @@ pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boo
         &BOOT_LOADER_VENDOR_UUID,
         default_attributes,
         || {
-            disk_get_part_uuid(boot_services, loaded_image.device()).map(|guid| {
+            disk_get_part_uuid(
+                boot_services,
+                loaded_image.device().ok_or(uefi::Status::NOT_FOUND)?,
+            )
+            .map(|guid| {
                 guid.to_string()
                     .encode_utf16()
                     .flat_map(|c| c.to_le_bytes())

--- a/rust/uefi/stub/Cargo.toml
+++ b/rust/uefi/stub/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.24.0", default-features = false, features = [ "alloc", "global_allocator" ] }
-uefi-services = { version = "0.21.0", default-features = false, features = [ "panic_handler", "logger" ] }
+uefi = { version = "0.25.0", default-features = false, features = [ "alloc", "global_allocator" ] }
+uefi-services = { version = "0.22.0", default-features = false, features = [ "panic_handler", "logger" ] }
 # Even in debug builds, we don't enable the debug logs, because they generate a lot of spam from goblin.
 log = { version = "0.4.19", default-features = false, features = [ "max_level_info", "release_max_level_warn" ]}
 # Use software implementation because the UEFI target seems to need it.

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use log::warn;
 use sha2::{Digest, Sha256};
+use uefi::fs::FileSystem;
 use uefi::{prelude::*, proto::loaded_image::LoadedImage, CStr16, CString16, Result};
 
 use crate::common::{boot_linux_unchecked, extract_string};
@@ -124,10 +125,11 @@ pub fn boot_linux(handle: Handle, mut system_table: SystemTable<Boot>) -> Status
     let initrd_data;
 
     {
-        let mut file_system = system_table
+        let file_system = system_table
             .boot_services()
             .get_image_file_system(handle)
             .expect("Failed to get file system handle");
+        let mut file_system = FileSystem::new(file_system);
 
         kernel_data = file_system
             .read(&*config.kernel_filename)


### PR DESCRIPTION
This updates our UEFI dependencies by dealing with some breaking changes.

Fixes #234. Unblocks #196.