### PR TITLE
Fix build with `documentation.nixos.includeAllModules = true;`

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -24,6 +24,7 @@ in
 
     configurationLimit = mkOption {
       default = config.boot.loader.systemd-boot.configurationLimit;
+      defaultText = "config.boot.loader.systemd-boot.configurationLimit";
       example = 120;
       type = types.nullOr types.int;
       description = lib.mdDoc ''
@@ -43,18 +44,21 @@ in
     publicKeyFile = mkOption {
       type = types.path;
       default = "${cfg.pkiBundle}/keys/db/db.pem";
+      defaultText = "\${cfg.pkiBundle}/keys/db/db.pem";
       description = "Public key to sign your boot files";
     };
 
     privateKeyFile = mkOption {
       type = types.path;
       default = "${cfg.pkiBundle}/keys/db/db.key";
+      defaultText = "\${cfg.pkiBundle}/keys/db/db.key";
       description = "Private key to sign your boot files";
     };
 
     package = mkOption {
       type = types.package;
       default = pkgs.lzbt;
+      defaultText = "pkgs.lzbt";
       description = "Lanzaboote tool (lzbt) package";
     };
 
@@ -71,6 +75,15 @@ in
         editor = config.boot.loader.systemd-boot.editor;
         default = "nixos-*";
       };
+
+      defaultText = ''
+        {
+          timeout = config.boot.loader.timeout;
+          console-mode = config.boot.loader.systemd-boot.consoleMode;
+          editor = config.boot.loader.systemd-boot.editor;
+          default = "nixos-*";
+        }
+      '';
 
       example = literalExpression ''
         {


### PR DESCRIPTION
This includes the options of all modules used in the evaluation, not just the ones from `<nixpkgs/nixos>` in the local manual.

Right now this breaks with

    error: attribute 'loader' missing

    at /nix/store/wf59fvxch3l5s7x0pnpfv7b26q6y010x-source/nix/modules/lanzaboote.nix:26:17:

        25|     configurationLimit = mkOption {
        26|       default = config.boot.loader.systemd-boot.configurationLimit;
          |                 ^
        27|       example = 120;

I'm not sure what's up with `config.boot.loader` (had the exact same issue with `disko`), but using `defaultText` is the common workaround for that.