### PR TITLE
stub: pin to current goblin version

### DIFF
--- a/rust/uefi/linux-bootloader/Cargo.toml
+++ b/rust/uefi/linux-bootloader/Cargo.toml
@@ -13,7 +13,8 @@ rust-version = "1.68"
 
 [dependencies]
 uefi = { version = "0.25.0", default-features = false, features = [ "alloc", "global_allocator" ] }
-goblin = { version = "0.6.1", default-features = false, features = [ "pe64", "alloc" ]}
+# Update blocked by #237
+goblin = { version = "=0.6.1", default-features = false, features = [ "pe64", "alloc" ]}
 bitflags = "2.3.3"
 
 # Even in debug builds, we don't enable the debug logs, because they generate a lot of spam from goblin.


### PR DESCRIPTION
This PR works around a goblin update problem and hopefully finally unblocks #196.

See #237 for context.