### PR TITLE
tests: add 5 minutes default timeout

### DIFF
--- a/nix/tests/lanzaboote.nix
+++ b/nix/tests/lanzaboote.nix
@@ -4,6 +4,7 @@
 
 let
   inherit (pkgs) lib system;
+  defaultTimeout = 5 * 60; # = 5 minutes
 
   mkSecureBootTest = { name, machine ? { }, useSecureBoot ? true, useTPM2 ? false, readEfiVariables ? false, testScript }:
     let
@@ -79,6 +80,7 @@ let
     in
     pkgs.nixosTest {
       inherit name;
+      globalTimeout = defaultTimeout;
 
       testScript = ''
         ${lib.optionalString useTPM2 tpm2Initialization}

--- a/nix/tests/stub.nix
+++ b/nix/tests/stub.nix
@@ -1,6 +1,7 @@
 { pkgs, runTest, ukiModule }:
 
 let
+  defaultTimeout = 5 * 60; # = 5 minutes
   common = _: {
     imports = [ ukiModule ];
 
@@ -21,6 +22,8 @@ in
   # this test fails something is very wrong.
   systemd-stub = runTest {
     name = "systemd-stub";
+    globalTimeout = defaultTimeout;
+
     nodes.machine = _: {
       imports = [ common ];
       boot.loader.uki.stub = "${pkgs.systemd}/lib/systemd/boot/efi/linuxx64.efi.stub";
@@ -33,6 +36,8 @@ in
 
   fatStub = runTest {
     name = "fat-stub";
+    globalTimeout = defaultTimeout;
+
     nodes.machine = _: {
       imports = [ common ];
     };


### PR DESCRIPTION
By default, it is one hour but our CI cannot handle that many VM tests, so we switch to 5 minutes default timeouts.