### PR TITLE
Remove Nondeterminism in Stub

### DIFF
--- a/rust/uefi/.cargo/config
+++ b/rust/uefi/.cargo/config
@@ -1,2 +1,4 @@
 [build]
 target = "x86_64-unknown-uefi"
+# Strip timestamps from binaries.
+rustflags = ["-C", "link-args=/Brepro"]


### PR DESCRIPTION
The linker embeds a timestamp into our UEFI stub. objdump -p reports:

```
Time/Date               Mon Nov 13 20:02:35 2023
```

With `/Brepro` we get the following instead:

```
Time/Date		d597e888	(This is a reproducible build file hash, not a timestamp)
```

Fixes #260