### PR TITLE
flake: remove "moving away the `unsupportedChecks`"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,10 +44,6 @@
         # we don't have KVM support and cannot test in CI, but we still can meaningfully
         # build packages.
         {
-          path = [ "legacyPackages" "unsupportedChecks" ];
-          update = checks: checks // (nixpkgs.lib.filterAttrs (name: _: !builtins.elem name supportedSystems) outputs.checks);
-        }
-        {
           path = [ "checks" ];
           update = nixpkgs.lib.filterAttrs (name: _: builtins.elem name supportedSystems);
         }


### PR DESCRIPTION
Alas, I don't know how to do this properly with Flakes, it is a sad state of affairs.

Fixes #264.