### PR TITLE
Small fixes & updates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -232,7 +232,6 @@
 
               # Convenience for test fixtures in nix/tests.
               pkgs.openssl
-              (pkgs.sbctl.override { databasePath = "pki"; })
 
               # Needed for `cargo test` in rust/tool. We also need
               # TEST_SYSTEMD below for that.

--- a/rust/uefi/linux-bootloader/src/pe_loader.rs
+++ b/rust/uefi/linux-bootloader/src/pe_loader.rs
@@ -195,7 +195,7 @@ impl Image {
                 self.image.len().try_into().unwrap(),
             );
             loaded_image.set_load_options(
-                load_options.as_ptr() as *const u8,
+                load_options.as_ptr(),
                 u32::try_from(load_options.len()).unwrap(),
             );
         }

--- a/rust/uefi/rust-toolchain.toml
+++ b/rust/uefi/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.75.0"
 components = [ "rust-src" ]
 targets = [ "x86_64-unknown-uefi", "aarch64-unknown-uefi" ]

--- a/rust/uefi/stub/src/fat.rs
+++ b/rust/uefi/stub/src/fat.rs
@@ -9,8 +9,7 @@ use linux_bootloader::uefi_helpers::booted_image_file;
 pub fn extract_bytes(pe_data: &[u8], section: &str) -> Result<Vec<u8>> {
     let bytes: Vec<u8> = pe_section(pe_data, section)
         .ok_or(Status::INVALID_PARAMETER)?
-        .try_into()
-        .map_err(|_| Status::INVALID_PARAMETER)?;
+        .into();
 
     Ok(bytes)
 }


### PR DESCRIPTION
- Remove sbctl from devShell as its annoying to rebuild
- Update Rust 1.70 -> 1.75 (fixes new clippy warnings)