### PR TITLE
UKI Compatibility for systemd 255

### DIFF
--- a/nix/tests/lanzaboote.nix
+++ b/nix/tests/lanzaboote.nix
@@ -202,6 +202,10 @@ in
     testScript = ''
       machine.start()
       assert "Secure Boot: enabled (user)" in machine.succeed("bootctl status")
+
+      # We want systemd to recognize our PE binaries as true UKIs. systemd has
+      # become more picky in the past, so make sure.
+      assert "Kernel Type: uki" in machine.succeed("bootctl kernel-inspect /boot/EFI/Linux/nixos-generation-1-*.efi")
     '';
   };
 

--- a/rust/tool/shared/src/pe.rs
+++ b/rust/tool/shared/src/pe.rs
@@ -47,10 +47,10 @@ pub fn lanzaboote_image(
     let sections = vec![
         s(".osrel", os_release, os_release_offs),
         s(".cmdline", kernel_cmdline_file, kernel_cmdline_offs),
-        s(".initrdp", initrd_path_file, initrd_path_offs),
-        s(".kernelp", kernel_path_file, kernel_path_offs),
+        s(".initrd", initrd_path_file, initrd_path_offs),
+        s(".linux", kernel_path_file, kernel_path_offs),
         s(".initrdh", initrd_hash_file, initrd_hash_offs),
-        s(".kernelh", kernel_hash_file, kernel_hash_offs),
+        s(".linuxh", kernel_hash_file, kernel_hash_offs),
     ];
 
     let image_path = tempdir.path().join(tmpname());

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -271,11 +271,11 @@ impl Installer {
         let stub = fs::read(&stub_target)?;
         let kernel_path = resolve_efi_path(
             &self.esp_paths.esp,
-            pe::read_section_data(&stub, ".kernelp").context("Missing kernel path.")?,
+            pe::read_section_data(&stub, ".linux").context("Missing kernel path.")?,
         )?;
         let initrd_path = resolve_efi_path(
             &self.esp_paths.esp,
-            pe::read_section_data(&stub, ".initrdp").context("Missing initrd path.")?,
+            pe::read_section_data(&stub, ".initrd").context("Missing initrd path.")?,
         )?;
 
         if !kernel_path.exists() && !initrd_path.exists() {

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -46,10 +46,10 @@ fn extract_hash(pe_data: &[u8], section: &str) -> Result<Hash> {
 impl EmbeddedConfiguration {
     fn new(file_data: &[u8]) -> Result<Self> {
         Ok(Self {
-            kernel_filename: extract_string(file_data, ".kernelp")?,
-            kernel_hash: extract_hash(file_data, ".kernelh")?,
+            kernel_filename: extract_string(file_data, ".linux")?,
+            kernel_hash: extract_hash(file_data, ".linuxh")?,
 
-            initrd_filename: extract_string(file_data, ".initrdp")?,
+            initrd_filename: extract_string(file_data, ".initrd")?,
             initrd_hash: extract_hash(file_data, ".initrdh")?,
 
             cmdline: extract_string(file_data, ".cmdline")?,


### PR DESCRIPTION
This PR renames section names in our thin stub:

- `.kernelp` -> `.linux`
- `.initrdp` -> `.initrd`
- `.kernelh` -> `.linuxh` (for consistency)

This allows `bootctl kernel-inspect` to properly parse our UKIs. Before it would not recognize them as UKIs.

We basically have to satisfy this function in systemd: https://github.com/systemd/systemd/blob/main/src/shared/pe-binary.c#L230

@nikstur Does this have backward compatibility issues?

Fixes #296. Relates to #295.