### PR TITLE
stub(*): support dynamic initrds

### DIFF
--- a/rust/uefi/stub/src/fat.rs
+++ b/rust/uefi/stub/src/fat.rs
@@ -40,7 +40,11 @@ impl EmbeddedConfiguration {
     }
 }
 
-pub fn boot_linux(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
+pub fn boot_linux(
+    handle: Handle,
+    mut system_table: SystemTable<Boot>,
+    dynamic_initrds: Vec<Vec<u8>>,
+) -> Status {
     uefi_services::init(&mut system_table).unwrap();
 
     // SAFETY: We get a slice that represents our currently running

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -15,6 +15,7 @@ mod thin;
 #[cfg(all(feature = "fat", feature = "thin"))]
 compile_error!("A thin and fat stub cannot be produced at the same time, disable either `thin` or `fat` feature");
 
+use alloc::vec::Vec;
 use linux_bootloader::efivars::{export_efi_variables, get_loader_features, EfiLoaderFeatures};
 use linux_bootloader::measure::measure_image;
 use linux_bootloader::tpm::tpm_available;
@@ -69,15 +70,18 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     export_efi_variables(STUB_NAME, &system_table).expect("Failed to export stub EFI variables");
 
     let status;
+    // A list of dynamically assembled initrds, e.g. credential initrds or system extension
+    // initrds.
+    let dynamic_initrds: Vec<Vec<u8>> = Vec::new();
 
     #[cfg(feature = "fat")]
     {
-        status = fat::boot_linux(handle, system_table)
+        status = fat::boot_linux(handle, system_table, dynamic_initrds)
     }
 
     #[cfg(feature = "thin")]
     {
-        status = thin::boot_linux(handle, system_table).status()
+        status = thin::boot_linux(handle, system_table, dynamic_initrds).status()
     }
 
     status

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -99,7 +99,7 @@ pub fn boot_linux(
     let secure_boot_enabled = get_secure_boot_status(system_table.runtime_services());
 
     let kernel_data;
-    let initrd_data;
+    let mut initrd_data;
 
     {
         let file_system = system_table
@@ -134,6 +134,14 @@ pub fn boot_linux(
         "Initrd",
         secure_boot_enabled,
     )?;
+
+    // Correctness: dynamic initrds are supposed to be validated by caller,
+    // i.e. they are system extension images or credentials
+    // that are supposedly measured in TPM2.
+    // Therefore, it is normal to not verify their hashes against a configuration.
+    for mut extra_initrd in dynamic_initrds {
+        initrd_data.append(&mut extra_initrd);
+    }
 
     boot_linux_unchecked(handle, system_table, kernel_data, &cmdline, initrd_data)
 }

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use log::{error, warn};
 use sha2::{Digest, Sha256};
 use uefi::{fs::FileSystem, prelude::*, CString16, Result};
@@ -75,7 +76,11 @@ fn check_hash(data: &[u8], expected_hash: Hash, name: &str, secure_boot: bool) -
     Ok(())
 }
 
-pub fn boot_linux(handle: Handle, mut system_table: SystemTable<Boot>) -> uefi::Result<()> {
+pub fn boot_linux(
+    handle: Handle,
+    mut system_table: SystemTable<Boot>,
+    dynamic_initrds: Vec<Vec<u8>>,
+) -> uefi::Result<()> {
     uefi_services::init(&mut system_table).unwrap();
 
     // SAFETY: We get a slice that represents our currently running


### PR DESCRIPTION
With this feature, it is now possible to load dynamic initrds (possibly read from filesystem or generated on the fly)
and extend existing initrds.

This feature will be useful to implement addons in the future.