### PR TITLE
stub: load companions

### DIFF
--- a/rust/uefi/Cargo.lock
+++ b/rust/uefi/Cargo.lock
@@ -105,7 +105,6 @@ dependencies = [
  "log",
  "sha2",
  "uefi",
- "uefi-services",
 ]
 
 [[package]]
@@ -310,15 +309,6 @@ dependencies = [
  "bitflags",
  "ptr_meta",
  "uguid",
-]
-
-[[package]]
-name = "uefi-services"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d502e54e05da57380e0b6f3cb1baa89860e4ae314afb5a17080ed14379b6e2"
-dependencies = [
- "uefi",
 ]
 
 [[package]]

--- a/rust/uefi/Cargo.lock
+++ b/rust/uefi/Cargo.lock
@@ -119,8 +119,10 @@ name = "linux-bootloader"
 version = "0.4.1"
 dependencies = [
  "bitflags",
+ "embedded-io",
  "goblin",
  "log",
+ "pio",
  "uefi",
 ]
 

--- a/rust/uefi/Cargo.toml
+++ b/rust/uefi/Cargo.toml
@@ -17,3 +17,7 @@ version = "0.4.1"
 [profile.release]
 opt-level = "s"
 lto = true
+
+[patch.crates-io]
+uefi = { git = "https://github.com/rust-osdev/uefi-rs" }
+uefi-services = { git = "https://github.com/rust-osdev/uefi-rs" }

--- a/rust/uefi/Cargo.toml
+++ b/rust/uefi/Cargo.toml
@@ -17,7 +17,3 @@ version = "0.4.1"
 [profile.release]
 opt-level = "s"
 lto = true
-
-[patch.crates-io]
-uefi = { git = "https://github.com/rust-osdev/uefi-rs" }
-uefi-services = { git = "https://github.com/rust-osdev/uefi-rs" }

--- a/rust/uefi/linux-bootloader/Cargo.toml
+++ b/rust/uefi/linux-bootloader/Cargo.toml
@@ -19,6 +19,8 @@ bitflags = "2.5.0"
 
 # Even in debug builds, we don't enable the debug logs, because they generate a lot of spam from goblin.
 log = { version = "0.4.21", default-features = false, features = [ "max_level_info", "release_max_level_warn" ]}
+pio = { path = "../pio" }
+embedded-io = { version = "0.6.1", default-features = false, features = [ "alloc" ] }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/rust/uefi/linux-bootloader/src/companions.rs
+++ b/rust/uefi/linux-bootloader/src/companions.rs
@@ -50,8 +50,10 @@ pub fn get_default_dropin_directory(
     // then opening the root directory and finding the new directory.
     let mut target_directory = loaded_image_file_path
         .to_string(boot_services, DisplayOnly(false), AllowShortcuts(false))
-        // This is the Result-level error
-        .expect("Failed to obtain the string representation of the loaded image file path");
+        .map_err(|_dpp_error| {
+            log::warn!("Failed to obtain string representation of the loaded image file path");
+            uefi::Error::new(uefi::Status::NOT_FOUND, ())
+        })?;
     target_directory.push_str(cstr16!(".extra"));
 
     Ok(fs

--- a/rust/uefi/linux-bootloader/src/companions.rs
+++ b/rust/uefi/linux-bootloader/src/companions.rs
@@ -1,0 +1,153 @@
+use crate::cpio::{pack_cpio, Cpio};
+use alloc::{string::ToString, vec::Vec};
+use uefi::{
+    cstr16,
+    fs::{Path, PathBuf},
+    prelude::BootServices,
+    proto::device_path::{
+        text::{AllowShortcuts, DisplayOnly},
+        DevicePath,
+    },
+    CString16,
+};
+
+/// Locate files with ASCII filenames and matching the suffix passed as a parameter.
+/// Returns a list of their paths.
+pub fn find_files(
+    fs: &mut uefi::fs::FileSystem,
+    search_path: &Path,
+    suffix: &str,
+) -> uefi::Result<Vec<PathBuf>> {
+    let mut results = Vec::new();
+
+    for maybe_entry in fs.read_dir(search_path).unwrap() {
+        let entry = maybe_entry?;
+        if entry.is_regular_file() {
+            let fname = entry.file_name();
+            if fname.is_ascii() && fname.to_string().ends_with(suffix) {
+                let mut full_path = CString16::from(search_path.to_cstr16());
+                full_path.push_str(cstr16!("\\"));
+                full_path.push_str(fname);
+                results.push(full_path.into());
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// Returns the "default" drop-in directory if it exists.
+/// This will be in general $loaded_image_path.extra/
+pub fn get_default_dropin_directory(
+    boot_services: &BootServices,
+    loaded_image_file_path: &DevicePath,
+    fs: &mut uefi::fs::FileSystem,
+) -> uefi::Result<Option<PathBuf>> {
+    // We could use LoadedImageDevicePath to get the full device path
+    // and perform replacement of the last node before END_ENTIRE
+    // by another node containing the filename + .extra
+    // But this is as much tedious as performing a conversion to string
+    // then opening the root directory and finding the new directory.
+    let mut target_directory = loaded_image_file_path
+        .to_string(boot_services, DisplayOnly(false), AllowShortcuts(false))
+        // This is the Result-level error
+        .expect("Failed to obtain the string representation of the loaded image file path");
+    target_directory.push_str(cstr16!(".extra"));
+
+    Ok(fs
+        .metadata(target_directory.as_ref())
+        .ok()
+        .and_then(|metadata| {
+            metadata
+                .is_directory()
+                .then(|| PathBuf::from(target_directory))
+        }))
+}
+
+pub enum CompanionInitrdType {
+    Credentials,
+    GlobalCredentials,
+    SystemExtension,
+    PcrSignature,
+    PcrPublicKey,
+}
+
+/// Potential companion initrd assembled on the fly
+/// during discovery workflows, e.g. finding files in drop-in directories.
+pub struct CompanionInitrd {
+    pub r#type: CompanionInitrdType,
+    pub cpio: Cpio,
+}
+
+/// Collect all credentials and return them as CPIO archive.
+///
+/// There are two variants of credentials:
+///   - global: `$ESP/loader.credentials/*.cred`
+///   - image-specific: `$path_to_image.extra/*.cred`
+///
+/// The credentials are not measured.
+pub fn discover_credentials(
+    fs: &mut uefi::fs::FileSystem,
+    default_dropin_dir: Option<&Path>,
+) -> uefi::Result<Vec<CompanionInitrd>> {
+    let mut companions = Vec::new();
+
+    let default_global_dropin_dir = cstr16!("\\loader\\credentials");
+    if fs.try_exists(default_global_dropin_dir).unwrap() {
+        let metadata = fs.metadata(default_global_dropin_dir).expect("Failed to obtain metadata on `\\loader\\credentials` path (which is supposed to exist)");
+        if metadata.is_directory() {
+            let global_credentials: Vec<PathBuf> =
+                find_files(fs, default_global_dropin_dir.as_ref(), ".cred")?;
+
+            if !global_credentials.is_empty() {
+                companions.push(CompanionInitrd {
+                    r#type: CompanionInitrdType::GlobalCredentials,
+                    cpio: pack_cpio(
+                        fs,
+                        global_credentials,
+                        ".extra/global_credentials",
+                        0o500,
+                        0o400,
+                    )
+                    .map_err(|_err| uefi::Status::LOAD_ERROR)?,
+                });
+            }
+        }
+    }
+
+    if let Some(default_dropin_dir) = default_dropin_dir {
+        let local_credentials: Vec<PathBuf> = find_files(fs, default_dropin_dir, ".cred")?;
+
+        if !local_credentials.is_empty() {
+            companions.push(CompanionInitrd {
+                r#type: CompanionInitrdType::Credentials,
+                cpio: pack_cpio(fs, local_credentials, ".extra/credentials", 0o500, 0o400)
+                    .map_err(|_err| uefi::Status::LOAD_ERROR)?,
+            });
+        }
+    }
+
+    Ok(companions)
+}
+/// Discover any system image extension, i.e. files ending by .raw
+/// They must be present inside $path_to_image.extra/*.raw, specific to this image.
+///
+/// Those will be unmeasured, you are responsible for measuring them or not.
+/// But CPIOs are guaranteed to be stable and independent of file discovery order.
+pub fn discover_system_extensions(
+    fs: &mut uefi::fs::FileSystem,
+    default_dropin_dir: &Path,
+) -> uefi::Result<Vec<CompanionInitrd>> {
+    let mut companions = Vec::new();
+    let sysexts = find_files(fs, default_dropin_dir, ".raw")?;
+
+    if !sysexts.is_empty() {
+        companions.push(CompanionInitrd {
+            r#type: CompanionInitrdType::SystemExtension,
+            cpio: pack_cpio(fs, sysexts, ".extra/sysext", 0o555, 0o444)
+                .map_err(|_err| uefi::Status::LOAD_ERROR)?,
+        });
+    }
+
+    Ok(companions)
+}

--- a/rust/uefi/linux-bootloader/src/companions.rs
+++ b/rust/uefi/linux-bootloader/src/companions.rs
@@ -96,7 +96,10 @@ pub fn discover_credentials(
 
     let default_global_dropin_dir = cstr16!("\\loader\\credentials");
     if fs.try_exists(default_global_dropin_dir).unwrap() {
-        let metadata = fs.metadata(default_global_dropin_dir).expect("Failed to obtain metadata on `\\loader\\credentials` path (which is supposed to exist)");
+        let metadata = fs.metadata(default_global_dropin_dir).map_err(|_err| {
+            log::warn!("Failed to obtain metadata on `\\loader\\credentials` path (which is supposed to exist)");
+            uefi::Error::new(uefi::Status::VOLUME_CORRUPTED, ())
+        })?;
         if metadata.is_directory() {
             let global_credentials: Vec<PathBuf> =
                 find_files(fs, default_global_dropin_dir.as_ref(), ".cred")?;

--- a/rust/uefi/linux-bootloader/src/cpio.rs
+++ b/rust/uefi/linux-bootloader/src/cpio.rs
@@ -1,0 +1,71 @@
+use core::convert::Infallible;
+
+use alloc::{string::String, vec::Vec};
+use pio::errors::CPIOError;
+use uefi::fs::{Path, PathBuf};
+
+pub type Cpio = pio::writer::Cpio<Infallible>;
+pub type Result = core::result::Result<Cpio, CPIOError<Infallible>>;
+
+/// Given a file contents and a filename, this will create an ad-hoc CPIO archive
+/// containing this single item inside.
+/// It is largely similar to `pack_cpio` except that it operates on a single file that is already
+/// in memory.
+pub fn pack_cpio_literal(
+    contents: &[u8],
+    target_filename: &Path,
+    target_dir_prefix: &str,
+    dir_mode: u32,
+    access_mode: u32,
+) -> Result {
+    let mut cpio = Cpio::new();
+
+    let utf8_filename = String::from(target_filename.to_cstr16());
+
+    cpio.pack_prefix(target_dir_prefix, dir_mode)?;
+    cpio.pack_one(&utf8_filename, contents, target_dir_prefix, access_mode)?;
+    cpio.pack_trailer()?;
+
+    Ok(cpio)
+}
+
+/// Given a list of filenames and a filesystem high-level interface,
+/// this will pack all those files in-memory in a CPIO archive (newc format)
+/// which will decompress to the provided `target_dir_prefix`.
+///
+/// In the CPIO archives, only the basename is retained as a filename.
+///
+/// For consistency of TPM2 measurements, the `files` list will be sorted in this function.
+///
+/// Target directory prefix will be created with `dir_mode` access privileges,
+/// files will be created with `access_mode`.
+///
+/// All prefixes of the target directory prefix excluding itself will be created with 555
+/// permission bits.
+pub fn pack_cpio(
+    fs: &mut uefi::fs::FileSystem,
+    mut files: Vec<PathBuf>,
+    target_dir_prefix: &str,
+    dir_mode: u32,
+    access_mode: u32,
+) -> Result {
+    let mut cpio = Cpio::new();
+
+    // Ensure consistency of the CPIO archive layout for future potential measurements via TPM2.
+    files.sort();
+
+    cpio.pack_prefix(target_dir_prefix, dir_mode)?;
+    for file in files {
+        let utf8_filename = String::from(
+            &file
+                .components()
+                .last()
+                .expect("Expected the filename to possess a file name!"),
+        );
+        let contents = fs.read(file).expect("failed to read");
+        cpio.pack_one(&utf8_filename, &contents, target_dir_prefix, access_mode)?;
+    }
+    cpio.pack_trailer()?;
+
+    Ok(cpio)
+}

--- a/rust/uefi/linux-bootloader/src/lib.rs
+++ b/rust/uefi/linux-bootloader/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate alloc;
 
+pub mod companions;
+pub mod cpio;
 pub mod efivars;
 pub mod linux_loader;
 pub mod measure;

--- a/rust/uefi/linux-bootloader/src/measure.rs
+++ b/rust/uefi/linux-bootloader/src/measure.rs
@@ -7,13 +7,24 @@ use uefi::{
 };
 
 use crate::{
-    efivars::BOOT_LOADER_VENDOR_UUID, pe_section::pe_section_data, tpm::tpm_log_event_ascii,
-    uefi_helpers::PeInMemory, unified_sections::UnifiedSection,
+    companions::{CompanionInitrd, CompanionInitrdType},
+    efivars::BOOT_LOADER_VENDOR_UUID,
+    pe_section::pe_section_data,
+    tpm::tpm_log_event_ascii,
+    uefi_helpers::PeInMemory,
+    unified_sections::UnifiedSection,
 };
 
+/// This is where any stub payloads are extended, e.g. kernel ELF image, embedded initrd
+/// and so on.
+/// Compared to PCR4, this contains only the unified sections rather than the whole PE image as-is.
 const TPM_PCR_INDEX_KERNEL_IMAGE: PcrIndex = PcrIndex(11);
+/// This is where lanzastub extends the kernel command line and any passed credentials into
+const TPM_PCR_INDEX_KERNEL_CONFIG: PcrIndex = PcrIndex(12);
+/// This is where we extend the initrd sysext images into which we pass to the booted kernel
+const TPM_PCR_INDEX_SYSEXTS: PcrIndex = PcrIndex(13);
 
-pub fn measure_image(system_table: &SystemTable<Boot>, image: PeInMemory) -> uefi::Result<u32> {
+pub fn measure_image(system_table: &SystemTable<Boot>, image: &PeInMemory) -> uefi::Result<u32> {
     let runtime_services = system_table.runtime_services();
     let boot_services = system_table.boot_services();
 
@@ -63,6 +74,84 @@ pub fn measure_image(system_table: &SystemTable<Boot>, image: PeInMemory) -> uef
             &BOOT_LOADER_VENDOR_UUID,
             VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS,
             &pcr_index_encoded,
+        )?;
+    }
+
+    Ok(measurements)
+}
+
+/// Performs all the expected measurements for any list of
+/// companion initrds of any form.
+///
+/// Relies on the passed order of `companions` for measurements in the same PCR.
+/// A stable order is expected for measurement stability.
+pub fn measure_companion_initrds(
+    system_table: &SystemTable<Boot>,
+    companions: &[CompanionInitrd],
+) -> uefi::Result<u32> {
+    let runtime_services = system_table.runtime_services();
+    let boot_services = system_table.boot_services();
+
+    let mut measurements = 0;
+    let mut credentials_measured = 0;
+    let mut sysext_measured = false;
+
+    for initrd in companions {
+        match initrd.r#type {
+            CompanionInitrdType::PcrSignature | CompanionInitrdType::PcrPublicKey => {
+                continue;
+            }
+            CompanionInitrdType::Credentials => {
+                if tpm_log_event_ascii(
+                    boot_services,
+                    TPM_PCR_INDEX_KERNEL_CONFIG,
+                    initrd.cpio.as_ref(),
+                    "Credentials initrd",
+                )? {
+                    measurements += 1;
+                    credentials_measured += 1;
+                }
+            }
+            CompanionInitrdType::GlobalCredentials => {
+                if tpm_log_event_ascii(
+                    boot_services,
+                    TPM_PCR_INDEX_KERNEL_CONFIG,
+                    initrd.cpio.as_ref(),
+                    "Global credentials initrd",
+                )? {
+                    measurements += 1;
+                    credentials_measured += 1;
+                }
+            }
+            CompanionInitrdType::SystemExtension => {
+                if tpm_log_event_ascii(
+                    boot_services,
+                    TPM_PCR_INDEX_SYSEXTS,
+                    initrd.cpio.as_ref(),
+                    "System extension initrd",
+                )? {
+                    measurements += 1;
+                    sysext_measured = true;
+                }
+            }
+        }
+    }
+
+    if credentials_measured > 0 {
+        runtime_services.set_variable(
+            cstr16!("StubPcrKernelParameters"),
+            &BOOT_LOADER_VENDOR_UUID,
+            VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS,
+            &TPM_PCR_INDEX_KERNEL_CONFIG.0.to_le_bytes(),
+        )?;
+    }
+
+    if sysext_measured {
+        runtime_services.set_variable(
+            cstr16!("StubPcrInitRDSysExts"),
+            &BOOT_LOADER_VENDOR_UUID,
+            VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS,
+            &TPM_PCR_INDEX_SYSEXTS.0.to_le_bytes(),
         )?;
     }
 

--- a/rust/uefi/linux-bootloader/src/uefi_helpers.rs
+++ b/rust/uefi/linux-bootloader/src/uefi_helpers.rs
@@ -1,9 +1,17 @@
 use core::ffi::c_void;
 
-use uefi::{prelude::BootServices, proto::loaded_image::LoadedImage, Result};
+use uefi::{
+    prelude::BootServices,
+    proto::{
+        device_path::{DevicePath, FfiDevicePath},
+        loaded_image::LoadedImage,
+    },
+    Result,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub struct PeInMemory {
+    image_device_path: Option<*const FfiDevicePath>,
     image_base: *const c_void,
     image_size: usize,
 }
@@ -22,6 +30,23 @@ impl PeInMemory {
     pub unsafe fn as_slice(&self) -> &'static [u8] {
         unsafe { core::slice::from_raw_parts(self.image_base as *const u8, self.image_size) }
     }
+
+    /// Return optionally a reference to the device path
+    /// relative to this image's simple file system.
+    pub fn file_path(&self) -> Option<&DevicePath> {
+        // SAFETY:
+        //
+        // The returned reference to the device path will be alive as long
+        // as `self` is alive as it relies on the thin internal pointer to remain around,
+        // which is guaranteed as long as the structure is not dropped.
+        //
+        // This means that the safety guarantees of [`uefi::device_path::DevicePath::from_ffi_ptr`]
+        // are guaranteed.
+        unsafe {
+            self.image_device_path
+                .map(|ptr| DevicePath::from_ffi_ptr(ptr))
+        }
+    }
 }
 
 /// Open the currently executing image as a file.
@@ -31,6 +56,7 @@ pub fn booted_image_file(boot_services: &BootServices) -> Result<PeInMemory> {
     let (image_base, image_size) = loaded_image.info();
 
     Ok(PeInMemory {
+        image_device_path: loaded_image.file_path().map(|dp| dp.as_ffi_ptr()),
         image_base,
         image_size: usize::try_from(image_size).map_err(|_| uefi::Status::INVALID_PARAMETER)?,
     })

--- a/rust/uefi/stub/Cargo.toml
+++ b/rust/uefi/stub/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.28.0", default-features = false, features = [ "alloc", "global_allocator" ] }
-uefi-services = { version = "0.25.0", default-features = false, features = [ "panic_handler", "logger" ] }
+uefi = { version = "0.28.0", default-features = false, features = [ "alloc", "global_allocator", "panic_handler", "logger" ] }
 # Even in debug builds, we don't enable the debug logs, because they generate a lot of spam from goblin.
 log = { version = "0.4.21", default-features = false, features = [ "max_level_info", "release_max_level_warn" ]}
 # Use software implementation because the UEFI target seems to need it.

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -16,6 +16,9 @@ mod thin;
 compile_error!("A thin and fat stub cannot be produced at the same time, disable either `thin` or `fat` feature");
 
 use alloc::vec::Vec;
+use linux_bootloader::companions::{
+    discover_credentials, discover_system_extensions, get_default_dropin_directory,
+};
 use linux_bootloader::efivars::{export_efi_variables, get_loader_features, EfiLoaderFeatures};
 use linux_bootloader::measure::measure_image;
 use linux_bootloader::tpm::tpm_available;
@@ -72,7 +75,60 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     let status;
     // A list of dynamically assembled initrds, e.g. credential initrds or system extension
     // initrds.
-    let dynamic_initrds: Vec<Vec<u8>> = Vec::new();
+    let mut dynamic_initrds: Vec<Vec<u8>> = Vec::new();
+
+    {
+        // This is a block for doing filesystem operations once and for all, related to companion
+        // files, nothing can open the LoadedImage protocol here.
+        // Everything must use `filesystem`.
+        let mut companions = Vec::new();
+        let mut filesystem = uefi::fs::FileSystem::new(
+            system_table
+                .boot_services()
+                .get_image_file_system(system_table.boot_services().image_handle())
+                .expect("Failed to open the simple filesystem for this image; netboot?"),
+        );
+        let default_dropin_directory;
+
+        if let Some(loaded_image_path) = pe_in_memory.file_path() {
+            default_dropin_directory = get_default_dropin_directory(
+                system_table.boot_services(),
+                loaded_image_path,
+                &mut filesystem,
+            )
+            .expect("Failed to obtain the default drop-in directory");
+        } else {
+            default_dropin_directory = None;
+        }
+
+        // TODO: how to do the proper .as_ref()? Should I take AsRef in the call definition… ?
+        companions.append(
+            &mut discover_credentials(
+                &mut filesystem,
+                default_dropin_directory.as_ref().map(|x| x.as_ref()),
+            )
+            .expect("Failed to discover system credentials"),
+        );
+        if let Some(default_dropin_dir) = default_dropin_directory {
+            companions.append(
+                &mut discover_system_extensions(&mut filesystem, &default_dropin_dir)
+                    .expect("Failed to discover system extensions"),
+            );
+        }
+
+        if is_tpm_available {
+            // TODO: in the future, devise a threat model where this can fail, see above
+            // measurements to understand the context.
+            let _ = measure_companion_initrds(&system_table, &companions);
+        }
+
+        dynamic_initrds.append(
+            &mut companions
+                .into_iter()
+                .map(|initrd| initrd.cpio.into_inner())
+                .collect(),
+        );
+    }
 
     #[cfg(feature = "fat")]
     {

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -20,7 +20,7 @@ use linux_bootloader::companions::{
     discover_credentials, discover_system_extensions, get_default_dropin_directory,
 };
 use linux_bootloader::efivars::{export_efi_variables, get_loader_features, EfiLoaderFeatures};
-use linux_bootloader::measure::measure_image;
+use linux_bootloader::measure::{measure_companion_initrds, measure_image};
 use linux_bootloader::tpm::tpm_available;
 use linux_bootloader::uefi_helpers::booted_image_file;
 use log::info;
@@ -50,18 +50,17 @@ fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
 
     print_logo();
 
-    if tpm_available(system_table.boot_services()) {
+    let is_tpm_available = tpm_available(system_table.boot_services());
+    let pe_in_memory = booted_image_file(system_table.boot_services())
+        .expect("Failed to extract the in-memory information about our own image");
+
+    if is_tpm_available {
         info!("TPM available, will proceed to measurements.");
         // Iterate over unified sections and measure them
         // For now, ignore failures during measurements.
         // TODO: in the future, devise a threat model where this can fail
         // and ensure this hard-fail correctly.
-        let _ = measure_image(
-            &system_table,
-            booted_image_file(system_table.boot_services()).unwrap(),
-        );
-        // TODO: Measure kernel parameters
-        // TODO: Measure sysexts
+        let _ = measure_image(&system_table, &pe_in_memory);
     }
 
     if let Ok(features) = get_loader_features(system_table.runtime_services()) {

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -1,3 +1,4 @@
+use alloc::vec;
 use alloc::vec::Vec;
 use log::{error, warn};
 use sha2::{Digest, Sha256};
@@ -139,8 +140,31 @@ pub fn boot_linux(
     // i.e. they are system extension images or credentials
     // that are supposedly measured in TPM2.
     // Therefore, it is normal to not verify their hashes against a configuration.
+
+    /// Compute the necessary padding based on the provided length
+    /// It returns None if no padding is necessary.
+    fn compute_pad4(len: usize) -> Option<Vec<u8>> {
+        let overhang = len % 4;
+        if overhang != 0 {
+            let repeat = 4 - overhang;
+            Some(vec![0u8; repeat])
+        } else {
+            None
+        }
+    }
+    if let Some(mut padding) = compute_pad4(initrd_data.len()) {
+        initrd_data.append(&mut padding);
+    }
+
     for mut extra_initrd in dynamic_initrds {
+        // Uncomment for maximal debugging pleasure.
+        // let debug_representation = extra_initrd.as_slice().escape_ascii().collect::<Vec<u8>>();
+        // log::warn!("{:?}", String::from_utf8_lossy(&debug_representation));
         initrd_data.append(&mut extra_initrd);
+        // Extra initrds ideally should be aligned, but just in case, let's verify this.
+        if let Some(mut padding) = compute_pad4(initrd_data.len()) {
+            initrd_data.append(&mut padding);
+        }
     }
 
     boot_linux_unchecked(handle, system_table, kernel_data, &cmdline, initrd_data)

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -143,28 +143,18 @@ pub fn boot_linux(
 
     /// Compute the necessary padding based on the provided length
     /// It returns None if no padding is necessary.
-    fn compute_pad4(len: usize) -> Option<Vec<u8>> {
-        let overhang = len % 4;
-        if overhang != 0 {
-            let repeat = 4 - overhang;
-            Some(vec![0u8; repeat])
-        } else {
-            None
-        }
-    }
-    if let Some(mut padding) = compute_pad4(initrd_data.len()) {
-        initrd_data.append(&mut padding);
+    fn compute_pad4(len: usize) -> Vec<u8> {
+        vec![0u8; (4 - (len % 4)) % 4]
     }
 
+    initrd_data.append(&mut compute_pad4(initrd_data.len()));
     for mut extra_initrd in dynamic_initrds {
         // Uncomment for maximal debugging pleasure.
         // let debug_representation = extra_initrd.as_slice().escape_ascii().collect::<Vec<u8>>();
         // log::warn!("{:?}", String::from_utf8_lossy(&debug_representation));
         initrd_data.append(&mut extra_initrd);
         // Extra initrds ideally should be aligned, but just in case, let's verify this.
-        if let Some(mut padding) = compute_pad4(initrd_data.len()) {
-            initrd_data.append(&mut padding);
-        }
+        initrd_data.append(&mut compute_pad4(initrd_data.len()));
     }
 
     boot_linux_unchecked(handle, system_table, kernel_data, &cmdline, initrd_data)


### PR DESCRIPTION
This makes use of the pio library to discover, charge, measures companions.
Depends on the dynamic initrds PR: https://github.com/nix-community/lanzaboote/pull/305.