### PR TITLE
tool(systemd): support global credentials installation

### DIFF
--- a/rust/tool/Cargo.lock
+++ b/rust/tool/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -639,9 +639,9 @@ checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 
 [[package]]
 name = "rustix"
-version = "0.38.21"
+version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
  "bitflags 2.4.1",
  "errno",

--- a/rust/tool/systemd/Cargo.toml
+++ b/rust/tool/systemd/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.108"
 sha2 = "0.10.8"
 tempfile = "3.8.1"
 nix = { version = "0.27.1", default-features = false, features = [ "fs" ] }
+walkdir = "2.4.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.12"
@@ -24,4 +25,3 @@ expect-test = "1.4.1"
 filetime = "0.2.23"
 rand = "0.8.5"
 goblin = "0.7.1"
-walkdir = "2.4.0"

--- a/rust/tool/systemd/src/cli.rs
+++ b/rust/tool/systemd/src/cli.rs
@@ -55,6 +55,14 @@ struct InstallCommand {
     #[arg(long, default_value_t = 1)]
     configuration_limit: usize,
 
+    /// Directory containing the global credentials to install in the ESP
+    #[arg(long)]
+    global_credentials_directory: Option<PathBuf>,
+
+    /// Directory containing the local credentials to install in the ESP for latest generation
+    #[arg(long)]
+    local_credentials_directory: Option<PathBuf>,
+
     /// EFI system partition mountpoint (e.g. efiSysMountPoint)
     esp: PathBuf,
 
@@ -102,6 +110,8 @@ fn install(args: InstallCommand) -> Result<()> {
         args.configuration_limit,
         args.esp,
         args.generations,
+        args.global_credentials_directory,
+        args.local_credentials_directory,
     )
     .install()
 }

--- a/rust/tool/systemd/src/esp.rs
+++ b/rust/tool/systemd/src/esp.rs
@@ -17,9 +17,10 @@ pub struct SystemdEspPaths {
     pub systemd_boot: PathBuf,
     pub loader: PathBuf,
     pub systemd_boot_loader_config: PathBuf,
+    pub global_credentials: PathBuf,
 }
 
-impl EspPaths<10> for SystemdEspPaths {
+impl EspPaths<11> for SystemdEspPaths {
     fn new(esp: impl AsRef<Path>, architecture: Architecture) -> Self {
         let esp = esp.as_ref();
         let efi = esp.join("EFI");
@@ -29,6 +30,7 @@ impl EspPaths<10> for SystemdEspPaths {
         let efi_efi_fallback_dir = efi.join("BOOT");
         let loader = esp.join("loader");
         let systemd_boot_loader_config = loader.join("loader.conf");
+        let global_credentials = loader.join("credentials");
 
         Self {
             esp: esp.to_path_buf(),
@@ -41,6 +43,7 @@ impl EspPaths<10> for SystemdEspPaths {
             systemd_boot: efi_systemd.join(architecture.systemd_filename()),
             loader,
             systemd_boot_loader_config,
+            global_credentials,
         }
     }
 
@@ -52,7 +55,7 @@ impl EspPaths<10> for SystemdEspPaths {
         &self.linux
     }
 
-    fn iter(&self) -> std::array::IntoIter<&PathBuf, 10> {
+    fn iter(&self) -> std::array::IntoIter<&PathBuf, 11> {
         [
             &self.esp,
             &self.efi,
@@ -64,6 +67,7 @@ impl EspPaths<10> for SystemdEspPaths {
             &self.systemd_boot,
             &self.loader,
             &self.systemd_boot_loader_config,
+            &self.global_credentials,
         ]
         .into_iter()
     }


### PR DESCRIPTION
Now, lzbt can install global credentials directories passed inside the ESP and
manage the lifecycle of it in a basic fashion.