### PR TITLE
tests: remove custom OVMF overrides

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708847675,
-        "narHash": "sha256-RUZ7KEs/a4EzRELYDGnRB6i7M1Izii3JD/LyzH0c6Tg=",
+        "lastModified": 1709271102,
+        "narHash": "sha256-Z2sBL/HRRTNABsU8E5XsP+FXBEyBoi6oMwm5bV7lSFw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2a34566b67bef34c551f204063faeecc444ae9da",
+        "rev": "09c1497ce5d4ed4a0edfdd44450d3048074cb300",
         "type": "github"
       },
       "original": {

--- a/nix/tests/lanzaboote.nix
+++ b/nix/tests/lanzaboote.nix
@@ -101,35 +101,7 @@ let
           useBootLoader = true;
           useEFIBoot = true;
 
-          # We actually only want to enable features in OVMF, but at
-          # the moment edk2 202308 is also broken. So we downgrade it
-          # here as well. How painful!
-          #
-          # See #240.
-          efi.OVMF =
-            let
-              edk2Version = "202305";
-              edk2Src = pkgs.fetchFromGitHub {
-                owner = "tianocore";
-                repo = "edk2";
-                rev = "edk2-stable${edk2Version}";
-                fetchSubmodules = true;
-                hash = "sha256-htOvV43Hw5K05g0SF3po69HncLyma3BtgpqYSdzRG4s=";
-              };
-
-              edk2 = pkgs.edk2.overrideAttrs (old: rec {
-                version = edk2Version;
-                src = edk2Src;
-              });
-            in
-            (pkgs.OVMF.override {
-              secureBoot = useSecureBoot;
-              tpmSupport = useTPM2; # This is needed otherwise OVMF won't initialize the TPM2 protocol.
-
-              edk2 = edk2;
-            }).overrideAttrs (old: {
-              src = edk2Src;
-            });
+          efi.OVMF = pkgs.OVMFFull.fd;
 
           qemu.options = lib.mkIf useTPM2 [
             "-chardev socket,id=chrtpm,path=${tpmSocketPath}"
@@ -147,7 +119,7 @@ let
         };
         boot.lanzaboote = {
           enable = true;
-          enrollKeys = lib.mkDefault true;
+          enrollKeys = useSecureBoot;
           pkiBundle = ./fixtures/uefi-keys;
         };
       };


### PR DESCRIPTION
I think the newest OVMF is working now, so we don't need to fetch the old version anymore.

Instead of doing custom overrides, we can also just use OVMFFull which includes all the necessary parts.

If this works, it supersedes #310 