### PR TITLE
Elaborate on entering Setup Mode

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -256,6 +256,11 @@ On Framework laptops (13th generation or newer) you can enter the setup mode lik
 
 When you are done, press F10 to save and exit.
 
+#### Other systems
+
+On certain systems (e.g. ASUS desktop motherboards), there is no explicit option to enter Setup Mode.
+Instead, choose the option to erase the existing Platform Key.
+
 ### Enrolling Keys
 
 Once you've booted your system into NixOS again, you have to enroll


### PR DESCRIPTION
I tested Lanzaboote yesterday and was confused as there was no obvious option to "enter Setup Mode". With some Google-fu I found out that [erasing the Platform Key](https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Putting_firmware_in_%22Setup_Mode%22) has the same effect.