### PR TITLE
fix: remove deprecated lib.mdDoc

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -27,7 +27,7 @@ in
       defaultText = "config.boot.loader.systemd-boot.configurationLimit";
       example = 120;
       type = types.nullOr types.int;
-      description = lib.mdDoc ''
+      description = ''
         Maximum number of latest generations in the boot menu.
         Useful to prevent boot partition running out of disk space.
 


### PR DESCRIPTION
See the following for more info:
- https://github.com/NixOS/nixpkgs/issues/300735 for the tracking issue
- https://github.com/NixOS/nixpkgs/pull/237557 for the changes in the manual
- https://github.com/NixOS/nixpkgs/pull/303841 removes all `lib.mdDoc` uses (13k changes)
- https://github.com/NixOS/nixpkgs/pull/304277 adds `mdDoc` back, fixes the warning & sets an explicit timeline for the final removal:

> lib.mdDoc will be removed from nixpkgs in 24.11. Option descriptions are now in Markdown by default; you can remove any remaining uses of lib.mdDoc.