### PR TITLE
use /run/pki rather than /tmp/pki

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -4,7 +4,7 @@ let
   cfg = config.boot.lanzaboote;
 
   sbctlWithPki = pkgs.sbctl.override {
-    databasePath = "/tmp/pki";
+    databasePath = "/run/pki";
   };
 
   loaderSettingsFormat = pkgs.formats.keyValue {
@@ -111,8 +111,8 @@ in
       enable = true;
       installHook = pkgs.writeShellScript "bootinstall" ''
         ${optionalString cfg.enrollKeys ''
-          mkdir -p /tmp/pki
-          cp -r ${cfg.pkiBundle}/* /tmp/pki
+          mkdir -p /run/pki
+          cp -r ${cfg.pkiBundle}/* /run/pki
           ${sbctlWithPki}/bin/sbctl enroll-keys --yes-this-might-brick-my-machine
         ''}
 


### PR DESCRIPTION
This prevents another unprivileged user from creating /tmp/pki and sbctl enrolling those keys instead

I would be open to using another directory, however at the moment key enrollment is not secure.