### PR TITLE
Fix encoding issues

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -29,6 +29,9 @@ in
   export-efivars = runTest ./lanzaboote/export-efivars.nix;
   export-efivars-tpm = runTest ./lanzaboote/export-efivars-tpm.nix;
 
+  systemd-pcrlock = runTest ./lanzaboote/systemd-pcrlock.nix;
+  systemd-measured-uki = runTest ./lanzaboote/systemd-measured-uki.nix;
+
   # Stub
   systemd-stub = runTest ./stub/systemd-stub.nix;
   fat-stub = runTest ./stub/fat-stub.nix;

--- a/nix/tests/lanzaboote/common/efivariables-helper.nix
+++ b/nix/tests/lanzaboote/common/efivariables-helper.nix
@@ -1,6 +1,4 @@
 ''
-  import struct
-
   SD_LOADER_GUID = "4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
   def read_raw_variable(var: str) -> bytes:
       attr_var = machine.succeed(f"cat /sys/firmware/efi/efivars/{var}-{SD_LOADER_GUID}").encode('raw_unicode_escape')
@@ -10,10 +8,6 @@
   def read_string_variable(var: str, encoding='utf-16-le') -> str:
       return read_raw_variable(var).decode(encoding).rstrip('\x00')
   # By default, it will read a 4 byte value, read `struct` docs to change the format.
-  def assert_variable_uint(var: str, expected: int, format: str = 'I'):
-      with subtest(f"Is `{var}` set to {expected} (uint)"):
-        value, = struct.unpack(f'<{format}', read_raw_variable(var))
-        assert value == expected, f"Unexpected variable value in `{var}`, expected: `{expected}`, actual: `{value}`"
   def assert_variable_string(var: str, expected: str, encoding='utf-16-le'):
       with subtest(f"Is `{var}` correctly set"):
           value = read_string_variable(var, encoding)

--- a/nix/tests/lanzaboote/export-efivars-tpm.nix
+++ b/nix/tests/lanzaboote/export-efivars-tpm.nix
@@ -22,6 +22,6 @@
           machine.succeed(f"test -e /sys/firmware/efi/efivars/{expected_var}-{SD_LOADER_GUID}")
 
     # "Static" parts of the UKI is measured in PCR11
-    assert_variable_uint("StubPcrKernelImage", 11)
+    assert_variable_string("StubPcrKernelImage", "11")
   '';
 }

--- a/nix/tests/lanzaboote/export-efivars.nix
+++ b/nix/tests/lanzaboote/export-efivars.nix
@@ -15,6 +15,8 @@ in
   };
 
   testScript = (import ./common/efivariables-helper.nix) + ''
+    import struct
+
     # We will choose to boot directly on the stub.
     # To perform this trick, we will boot first with systemd-boot.
     # Then, we will add a new boot entry in EFI with higher priority

--- a/nix/tests/lanzaboote/systemd-measured-uki.nix
+++ b/nix/tests/lanzaboote/systemd-measured-uki.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }:
+
+{
+  name = "lanzaboote-systemd-measured-uki";
+
+  nodes.machine = { config, lib, pkgs, ... }: {
+    imports = [ ./common/lanzaboote.nix ];
+
+    virtualisation.tpm.enable = true;
+  };
+
+  testScript = ''
+    machine.start()
+
+    with subtest("Check if systemd considers measured-uki condition met"):
+      machine.succeed("systemd-analyze condition ConditionSecurity=measured-uki")
+
+    with subtest("Check if systemd-measure finds the correct PCR index"):
+      (status, measure_out) = machine.execute("${pkgs.systemd}/lib/systemd/systemd-measure 2>&1")
+      assert "Failed to parse EFI variable" not in measure_out, "systemd-measure failed to parse EFI variable - encoding issue?"
+  '';
+}
+

--- a/nix/tests/lanzaboote/systemd-pcrlock.nix
+++ b/nix/tests/lanzaboote/systemd-pcrlock.nix
@@ -1,0 +1,68 @@
+{ pkgs, ... }:
+
+{
+  name = "lanzaboote-systemd-pcrlock";
+
+  nodes.machine = { config, pkgs, ... }: {
+    imports = [ ./common/lanzaboote.nix ];
+
+    virtualisation.tpm.enable = true;
+
+    boot.initrd.systemd.storePaths = [
+      "${config.systemd.package}/lib/systemd/systemd-pcrextend"
+      "${pkgs.tpm2-tss}/lib"
+    ];
+
+    boot.initrd.systemd.additionalUpstreamUnits = [
+      "systemd-pcrphase-initrd.service"
+    ];
+
+    systemd.additionalUpstreamSystemUnits = [
+      "systemd-pcrphase-initrd.service"
+
+      "systemd-pcrphase.service"
+      "systemd-pcrphase-sysinit.service"
+    ];
+
+    boot.initrd.systemd.services.systemd-pcrphase-initrd = {
+      wantedBy = [ "initrd.target" ];
+    };
+
+    systemd.services.systemd-pcrphase-sysinit = {
+      wantedBy = [ "sysinit.target" ];
+    };
+
+    systemd.services.systemd-pcrphase = {
+      wantedBy = [ "sysinit.target" ];
+    };
+
+    boot.initrd.kernelModules = [ "tpm_tis" ];
+
+    environment.etc = {
+      systemd-pcrlock-builtin = {
+        target = "pcrlock.d";
+        source = "${config.systemd.package}/lib/pcrlock.d";
+      };
+    };
+  };
+
+  testScript = (import ./common/efivariables-helper.nix) + ''
+    import json
+
+    machine.start()
+
+    with subtest("Check if systemd-pcrphase measurements have been made"):
+      machine.succeed("systemctl is-active systemd-pcrphase.service")
+      machine.succeed("systemctl is-active systemd-pcrphase-sysinit.service")
+    
+    with subtest("Check if all expected IPL measurements are present"):
+      (status, log_json) = machine.execute("${pkgs.systemd}/lib/systemd/systemd-pcrlock log --json=short")
+      log_data = json.loads(log_json)
+
+      ipl_entries = [entry["description"] for entry in log_data["log"] if entry["pcr"] == 11 and entry["event"] == "ipl"]
+
+      for section in [".osrel", ".cmdline", ".initrd", ".linux"]:
+          assert f"String: {section}" in ipl_entries, f"Failed to find IPL measurement for section `{section}`"
+  '';
+}
+


### PR DESCRIPTION
Lanzaboote was not storing some strings in UTF-16 as required. This results in garbled output in systemd-pcrlock, for example. 

Note: systemd-pcrlock itself is not operational in NixOS without further tinkering, but that is beyond the scope of this PR. With this PR, systemd-pcrlock shows descriptions correctly and systemd-measure does not complain that the stub didn't measure correctly.