### PR TITLE
Remove an IFD caused by Crane in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,7 +142,7 @@
 
           stubCrane = buildRustApp {
             pname = "lanzaboote-stub";
-            src = craneLib.cleanCargoSource ./rust/uefi;
+            src = ./rust/uefi;
             target = rustTarget;
             doCheck = false;
           };


### PR DESCRIPTION
Before this commit, we use cranelib.cleanCargoSource[1] to filter files in the ./rust/uefi directory. This prevents some rebuilds when files that do not contribute to the build are changed (e.g. a README). However, this causes lanzaboote's flake.nix to contain an IFD[2]. This seems to be unavoidable when using cleanCargoSource[3].

Why this is useful anyway:

Since `nix flake check` must check all outputs of the given flake, it's not possible to split a flake check across multiple builder machines. This means that `nix flake check` without `--no-build` can only work if the builder machine has support to build for all architectures present in that flake's `nixosConfigurations` output. This is achievable with binfmt emulation, but excruciatingly slow, especially for use-cases like "run nix flake check in CI". In practice this means that a flake containing nixosConfiguration outputs with different `system` attributes can generally only be `nix flake check`'d with `--no-build`. See [4] for a long discussion on this.

Unfortunately, this affects flakes using Lanzaboote transitively. So any flake containing Lanzaboote-enabled nixosConfigurations (like mine[5]) are not be able to use `nix flake check --no-build`.

This commit corrects this by removing the IFD. This can be tested with:

$ nix store gc   # to ensure IFD paths are not cached
$ nix flake check --no-build github:nix-community/lanzaboote  # fails
$ nix store gc
$ nix flake check --no-build github:korfuri/lanzaboote  # succeeds

[1] https://crane.dev/API.html#cranelibfiltercargosources
[2] https://nix.dev/manual/nix/2.22/language/import-from-derivation
[3] https://github.com/ipetkov/crane/issues/612
[4] https://github.com/NixOS/nix/issues/4265
[5] https://gitlab.com/korfuri/infra/-/blob/77635232eb65e877d8b79eb98f6264381231c20c/flake.nix