### PR TITLE
Reorganize tests & add sort-key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Added `boot.lanzaboote.sortKey` option. This can be used to add a custom
+  `sort-key` to your boot entries.

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -100,11 +100,24 @@ in
         See `loader.conf(5)` for supported values.
       '';
     };
+
+    sortKey = mkOption {
+      default = "lanzaboote";
+      type = lib.types.str;
+      description = ''
+        The sort key used for the NixOS bootloader entries. This key determines
+        sorting relative to non-NixOS entries. See also
+        https://uapi-group.org/specifications/specs/boot_loader_specification/#sorting
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
     boot.bootspec = {
       enable = true;
+      extensions."org.nix-community.lanzaboote" = {
+        sort_key = config.boot.lanzaboote.sortKey;
+      };
     };
     boot.loader.supportsInitrdSecrets = true;
     boot.loader.external = {

--- a/nix/tests/lanzaboote/basic.nix
+++ b/nix/tests/lanzaboote/basic.nix
@@ -1,15 +1,20 @@
+let
+  sortKey = "mySpecialSortKey";
+in
 {
 
   name = "lanzaboote";
 
-
   nodes.machine = {
     imports = [ ./common/lanzaboote.nix ];
+
+    boot.lanzaboote = { inherit sortKey; };
   };
 
   testScript = ''
     machine.start()
     assert "Secure Boot: enabled (user)" in machine.succeed("bootctl status")
+    assert "sort-key: ${sortKey}" in machine.succeed("bootctl status")
 
     # We want systemd to recognize our PE binaries as true UKIs. systemd has
     # become more picky in the past, so make sure.

--- a/nix/tests/lanzaboote/common/lanzaboote.nix
+++ b/nix/tests/lanzaboote/common/lanzaboote.nix
@@ -9,6 +9,7 @@
   };
 
   boot = {
+    loader.timeout = 0;
     loader.efi.canTouchEfiVariables = true;
 
     lanzaboote = {

--- a/rust/tool/Cargo.lock
+++ b/rust/tool/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.6"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.6"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -440,6 +440,7 @@ dependencies = [
  "fastrand",
  "goblin",
  "log",
+ "serde",
  "serde_json",
  "sha2",
  "tempfile",
@@ -631,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 
 [[package]]
 name = "rustix"
@@ -845,9 +846,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/rust/tool/shared/Cargo.toml
+++ b/rust/tool/shared/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 [dependencies]
 anyhow = "1"
 goblin = "0.7"
+serde = "1"
 serde_json = "1"
 tempfile = "3.10.1"
 bootspec = "1"

--- a/rust/tool/shared/src/os_release.rs
+++ b/rust/tool/shared/src/os_release.rs
@@ -25,7 +25,10 @@ impl OsRelease {
         //
         // Because the ID field here does not have the same meaning as in a real os-release file,
         // it is fine to use a dummy value.
-        map.insert("ID".into(), String::from("lanza"));
+        map.insert(
+            "ID".into(),
+            generation.spec.lanzaboote_extension.sort_key.clone(),
+        );
 
         // systemd-boot will only show VERSION_ID when PRETTY_NAME is not unique. This is
         // confusing to users. Make sure that our PRETTY_NAME is unique, so we get a consistent

--- a/rust/tool/systemd/tests/integration/common.rs
+++ b/rust/tool/systemd/tests/integration/common.rs
@@ -71,7 +71,9 @@ pub fn setup_generation_link_from_toplevel(
           "toplevel": toplevel,
           "system": SYSTEM,
         },
-        "org.nixos-community.lanzaboote": { "osRelease": toplevel.join("os-release") }
+        "org.nix-community.lanzaboote": {
+            "sort_key": "lanzaboote",
+        }
     });
 
     let generation_link_path = profiles_directory.join(format!("system-{}-link", version));

--- a/rust/tool/systemd/tests/integration/common.rs
+++ b/rust/tool/systemd/tests/integration/common.rs
@@ -1,8 +1,3 @@
-// Utility code in this module can become marked as dead code if it is not used in every single
-// module in `tests/`. Thus we need to allow dead code here. See
-// https://stackoverflow.com/a/67902444
-#![allow(dead_code)]
-
 use std::ffi::OsStr;
 use std::fs;
 use std::io::Write;

--- a/rust/tool/systemd/tests/integration/gc.rs
+++ b/rust/tool/systemd/tests/integration/gc.rs
@@ -4,9 +4,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use tempfile::tempdir;
 
-mod common;
-
-use common::count_files;
+use crate::common::{self, count_files};
 
 #[test]
 fn keep_only_configured_number_of_generations() -> Result<()> {

--- a/rust/tool/systemd/tests/integration/install.rs
+++ b/rust/tool/systemd/tests/integration/install.rs
@@ -2,10 +2,9 @@ use anyhow::Result;
 use base32ct::{Base32Unpadded, Encoding};
 use tempfile::tempdir;
 
-mod common;
-
-use common::{
-    count_files, hash_file, remove_signature, setup_generation_link_from_toplevel, verify_signature,
+use crate::common::{
+    self, count_files, hash_file, remove_signature, setup_generation_link_from_toplevel,
+    verify_signature,
 };
 
 /// Install two generations that point at the same toplevel.

--- a/rust/tool/systemd/tests/integration/main.rs
+++ b/rust/tool/systemd/tests/integration/main.rs
@@ -1,0 +1,5 @@
+mod common;
+mod gc;
+mod install;
+mod os_release;
+mod systemd_boot;

--- a/rust/tool/systemd/tests/integration/os_release.rs
+++ b/rust/tool/systemd/tests/integration/os_release.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use expect_test::expect;
 use tempfile::tempdir;
 
-mod common;
+use crate::common;
 
 #[test]
 fn generate_expected_os_release() -> Result<()> {

--- a/rust/tool/systemd/tests/integration/os_release.rs
+++ b/rust/tool/systemd/tests/integration/os_release.rs
@@ -26,7 +26,7 @@ fn generate_expected_os_release() -> Result<()> {
         .to_owned();
 
     let expected = expect![[r#"
-        ID=lanza
+        ID=lanzaboote
         PRETTY_NAME=LanzaOS (Generation 1, 1970-01-01)
         VERSION_ID=Generation 1, 1970-01-01
     "#]];

--- a/rust/tool/systemd/tests/integration/systemd_boot.rs
+++ b/rust/tool/systemd/tests/integration/systemd_boot.rs
@@ -6,9 +6,7 @@ use lanzaboote_tool::architecture::Architecture;
 use lzbt_systemd::architecture::SystemdArchitectureExt;
 use tempfile::tempdir;
 
-mod common;
-
-use common::{hash_file, mtime, remove_signature, verify_signature, SYSTEM};
+use crate::common::{self, hash_file, mtime, remove_signature, verify_signature, SYSTEM};
 
 #[test]
 fn keep_systemd_boot_binaries() -> Result<()> {


### PR DESCRIPTION
- Reorganize integration tests
- ~~Reorganize crates (names and directories) to be more consistent~~
- Set boot loader timeout to 0 to speed up NixOS tests
- Add `boot.lanzaboote.sortKey` option. Closes #349 

Review commit by commit.