### PR TITLE
Update the crane flake input to prevent IFDs when building the UEFI stub

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717535930,
-        "narHash": "sha256-1hZ/txnbd/RmiBPNUs7i8UQw2N89uAK3UzrGAWdnFfU=",
+        "lastModified": 1718078026,
+        "narHash": "sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "55e7754ec31dac78980c8be45f8a28e80e370946",
+        "rev": "a3f0c63eed74a516298932b9b1627dd80b9c3892",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'crane':
    'github:ipetkov/crane/55e7754ec31dac78980c8be45f8a28e80e370946' (2024-06-04)
  → 'github:ipetkov/crane/a3f0c63eed74a516298932b9b1627dd80b9c3892' (2024-06-11)

This pulls in fixes discussed in https://github.com/ipetkov/crane/issues/612. See also https://github.com/nix-community/lanzaboote/pull/355 for a previous attempt by yours truly at fixing it. Note that this flake update does not come with the previous downside of removing source filtering.

Tested:

```
$ nix store gc && nix flake check --no-build github:nix-community/lanzaboote
14 store paths deleted, 233.67 MiB freed
error:
       … while checking flake output 'packages'

         at «none»:0: (source not available)

       … while checking the derivation 'packages.x86_64-linux.tool'

         at «none»:0: (source not available)

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: path '/nix/store/icamfwyn8jwyqgx7hhaf4dqxj2i3vf9f-source' is not valid
$ nix store gc && nix flake check --no-build github:korfuri/lanzaboote/update-flake
6 store paths deleted, 232.24 MiB freed
warning: The check omitted these incompatible systems: aarch64-linux
Use '--all-systems' to check all.
```