### PR TITLE
feat: add `nixpkgs-stable` as a follows to pre-commit-hooks-nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-stable-small";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
@@ -12,6 +13,7 @@
     pre-commit-hooks-nix = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs-stable.follows = "nixpkgs-stable";
       inputs.flake-compat.follows = "flake-compat";
     };
 
@@ -42,7 +44,7 @@
         # Derive the output overlay automatically from all packages that we define.
         inputs.flake-parts.flakeModules.easyOverlay
 
-        # Formatting and quality checks. 
+        # Formatting and quality checks.
       ] ++ (if inputs.pre-commit-hooks-nix ? flakeModule then [ inputs.pre-commit-hooks-nix.flakeModule ] else [ ]);
 
       flake.nixosModules.lanzaboote = moduleWithSystem (


### PR DESCRIPTION
Thanks for this great bootloader, it works like a charm.

I've noticed when running `nix flake metadata` that this input imports it's own version of nixpkgs. By pinning this at the top, you could allow users to forward their own version of `nixpkgs-stable`:

```
───lanzaboote: github:nix-community/lanzaboote/b627ccd97d0159214cee5c7db1412b75e4be6086
│   ├───crane: github:ipetkov/crane/0095fd8ea00ae0a9e6014f39c375e40c2fbd3386
│   │   └───nixpkgs follows input 'lanzaboote/nixpkgs'
│   ├───flake-compat: github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33
│   ├───flake-parts: github:hercules-ci/flake-parts/2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8
│   │   └───nixpkgs-lib follows input 'lanzaboote/nixpkgs'
│   ├───flake-utils: github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a
│   │   └───systems: github:nix-systems/default/da67096a3b9bf56a91d16901293e51ba5b49a27e
│   ├───nixpkgs follows input 'nixpkgs'
│   ├───pre-commit-hooks-nix: github:cachix/pre-commit-hooks.nix/cc4d466cb1254af050ff7bdf47f6d404a7c646d1
│   │   ├───flake-compat follows input 'lanzaboote/flake-compat'
│   │   ├───gitignore: github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394
│   │   │   └───nixpkgs follows input 'lanzaboote/pre-commit-hooks-nix/nixpkgs'
│   │   ├───nixpkgs follows input 'lanzaboote/nixpkgs'
│   │   └───nixpkgs-stable: github:NixOS/nixpkgs/614b4613980a522ba49f0d194531beddbb7220d3 <----- can then be edited
│   └───rust-overlay: github:oxalica/rust-overlay/0043c3f92304823cc2c0a4354b0feaa61dfb4cd9
│       ├───flake-utils follows input 'lanzaboote/flake-utils'
│       └───nixpkgs follows input 'lanzaboote/nixpkgs'
```

I would like to contribute more to this repo, but am not an expert on bootloaders. Does providing a log of my system booting help?