### PR TITLE
add option lanzaboote.generateKeysIfNotExist

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -126,8 +126,8 @@ in
       enable = true;
       installHook = pkgs.writeShellScript "bootinstall" ''
         ${optionalString cfg.generateKeysIfNotExist ''
-          if [ -f "${cfg.privateKeyFile}" ]; then
-            mkdir ${cfg.pkiBundle}
+          if [ ! -f "${cfg.privateKeyFile}" ]; then
+            mkdir -p ${cfg.pkiBundle}
             ${sbctlWithPki}/bin/sbctl create-keys \
               -d ${cfg.pkiBundle} \
               -e ${cfg.pkiBundle}/keys


### PR DESCRIPTION
generateKeysIfNotExist generates the PKI bundle if it doesn't already exist.
This is useful for single command setups.