### PR TITLE
Xen support

### DIFF
--- a/rust/tool/shared/src/generation.rs
+++ b/rust/tool/shared/src/generation.rs
@@ -102,7 +102,10 @@ impl Generation {
             spec: ExtendedBootJson {
                 bootspec: bootspec.clone(),
                 lanzaboote_extension: self.spec.lanzaboote_extension.clone(),
-                xen_extension: self.spec.xen_extension.clone(),
+                // TODO: It is only possible to use xen with toplevel system derivation, as there is no
+                // extension fields for bootspec generation anymore:
+                // https://github.com/DeterminateSystems/bootspec/issues/147
+                xen_extension: None,
             },
             ..self.clone()
         }

--- a/rust/tool/shared/src/generation.rs
+++ b/rust/tool/shared/src/generation.rs
@@ -42,6 +42,7 @@ pub struct XenExtension {
     pub xen: String,
     #[serde(rename = "xenParams")]
     pub xen_params: Vec<String>,
+    pub vmlinux: String,
 }
 
 /// A system configuration.

--- a/rust/tool/shared/src/pe.rs
+++ b/rust/tool/shared/src/pe.rs
@@ -4,7 +4,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use goblin::pe::PE;
 use tempfile::TempDir;
 
@@ -37,24 +37,59 @@ pub fn lanzaboote_image(
         tempdir.write_secure_file(esp_relative_uefi_path(esp, initrd_target)?)?;
     let initrd_hash_file = tempdir.write_secure_file(file_hash(initrd_source)?.as_slice())?;
 
-    let os_release_offs = stub_offset(lanzaboote_stub)?;
-    let kernel_cmdline_offs = os_release_offs + file_size(os_release)?;
-    let initrd_path_offs = kernel_cmdline_offs + file_size(&kernel_cmdline_file)?;
-    let kernel_path_offs = initrd_path_offs + file_size(&initrd_path_file)?;
-    let initrd_hash_offs = kernel_path_offs + file_size(&kernel_path_file)?;
-    let kernel_hash_offs = initrd_hash_offs + file_size(&initrd_hash_file)?;
-
-    let sections = vec![
-        s(".osrel", os_release, os_release_offs),
-        s(".cmdline", kernel_cmdline_file, kernel_cmdline_offs),
-        s(".initrd", initrd_path_file, initrd_path_offs),
-        s(".linux", kernel_path_file, kernel_path_offs),
-        s(".initrdh", initrd_hash_file, initrd_hash_offs),
-        s(".linuxh", kernel_hash_file, kernel_hash_offs),
+    let mut sections = vec![
+        s(".osrel", os_release),
+        s(".cmdline", kernel_cmdline_file),
+        s(".initrd", initrd_path_file),
+        s(".linux", kernel_path_file),
+        s(".initrdh", initrd_hash_file),
+        s(".linuxh", kernel_hash_file),
     ];
+    calculate_offsets(stub_offset(lanzaboote_stub)?, &mut sections)?;
 
     let image_path = tempdir.path().join(tmpname());
     wrap_in_pe(lanzaboote_stub, sections, &image_path)?;
+    Ok(image_path)
+}
+
+// FIXME: This function generates huge images, as it copies kernel & initrd inside,
+// lanzaboote stub needs to be extended to support xen images.
+#[allow(clippy::too_many_arguments)]
+pub fn xen_image(
+    tempdir: &TempDir,
+    xen_stub: &Path,
+    xen_options: &[String],
+    kernel_cmdline: &[String],
+    kernel: &Path,
+    initrd: &Path,
+) -> Result<PathBuf> {
+    use std::fmt::Write;
+    let mut xen_config = String::new();
+    writeln!(xen_config, "[global]")?;
+    writeln!(xen_config, "default=xen")?;
+    writeln!(xen_config)?;
+    writeln!(xen_config, "[xen]")?;
+    writeln!(
+        xen_config,
+        "kernel=nope_this_is_uxi {}",
+        kernel_cmdline.join(" ")
+    )?;
+    writeln!(xen_config, "ramdisk=nope_this_is_uxi")?;
+    writeln!(xen_config, "options={}", xen_options.join(" "),)?;
+    let xen_config_file = tempdir.write_secure_file(xen_config)?;
+
+    ensure!(kernel.ends_with("vmlinux"), "kernel is not vmlinux image");
+
+    let mut sections = vec![
+        s(".config", xen_config_file),
+        s(".kernel", kernel),
+        s(".ramdisk", initrd),
+    ];
+
+    calculate_offsets(xen_offset(xen_stub)?, &mut sections)?;
+
+    let image_path = tempdir.path().join(tmpname());
+    wrap_in_pe(xen_stub, sections, &image_path)?;
     Ok(image_path)
 }
 
@@ -89,9 +124,13 @@ struct Section {
 }
 
 impl Section {
+    fn resolved_offset(&self) -> bool {
+        self.offset != u64::MAX
+    }
     /// Create objcopy `-add-section` command line parameters that
     /// attach the section to a PE file.
     fn to_objcopy(&self) -> Vec<OsString> {
+        assert!(self.resolved_offset(), "section offset is not resolved!");
         // There is unfortunately no format! for OsString, so we cannot
         // just format a path.
         let mut map_str: OsString = format!("{}=", self.name).into();
@@ -106,12 +145,25 @@ impl Section {
     }
 }
 
-fn s(name: &'static str, file_path: impl AsRef<Path>, offset: u64) -> Section {
+fn s(name: &'static str, file_path: impl AsRef<Path>) -> Section {
     Section {
         name,
         file_path: file_path.as_ref().into(),
-        offset,
+        offset: u64::MAX,
     }
+}
+// EFI sections needs to be 4k aligned
+fn align_to_4k(num: u64) -> u64 {
+    (num + 0xFFF) & !0xFFF
+}
+fn calculate_offsets(mut current: u64, sections: &mut [Section]) -> Result<()> {
+    for section in sections.iter_mut() {
+        current = align_to_4k(current);
+        assert!(!section.resolved_offset(), "section offset is known");
+        section.offset = current;
+        current += file_size(&section.file_path)?;
+    }
+    Ok(())
 }
 
 /// Convert a path to an UEFI path relative to the specified ESP.
@@ -148,6 +200,20 @@ fn stub_offset(binary: &Path) -> Result<u64> {
             .map(|s| s.virtual_size + s.virtual_address)
             .expect("Failed to calculate offset"),
     ) + image_base)
+}
+fn xen_offset(binary: &Path) -> Result<u64> {
+    let pe_binary = fs::read(binary).context("Failed to read PE binary file")?;
+    let pe = PE::parse(&pe_binary).context("Failed to parse PE binary file")?;
+
+    let image_base = image_base(&pe);
+
+    let pad_section = pe
+        .sections
+        .iter()
+        .find(|s| s.name().ok() == Some(".pad"))
+        .expect("failed to discover .pad section");
+    let offset = pad_section.virtual_size + pad_section.virtual_address;
+    Ok(u64::from(offset) + image_base)
 }
 
 fn image_base(pe: &PE) -> u64 {

--- a/rust/tool/systemd/src/esp.rs
+++ b/rust/tool/systemd/src/esp.rs
@@ -16,10 +16,11 @@ pub struct SystemdEspPaths {
     pub systemd: PathBuf,
     pub systemd_boot: PathBuf,
     pub loader: PathBuf,
+    pub entries: PathBuf,
     pub systemd_boot_loader_config: PathBuf,
 }
 
-impl EspPaths<10> for SystemdEspPaths {
+impl EspPaths<11> for SystemdEspPaths {
     fn new(esp: impl AsRef<Path>, architecture: Architecture) -> Self {
         let esp = esp.as_ref();
         let efi = esp.join("EFI");
@@ -28,6 +29,7 @@ impl EspPaths<10> for SystemdEspPaths {
         let efi_systemd = efi.join("systemd");
         let efi_efi_fallback_dir = efi.join("BOOT");
         let loader = esp.join("loader");
+        let entries = loader.join("entries");
         let systemd_boot_loader_config = loader.join("loader.conf");
 
         Self {
@@ -40,6 +42,7 @@ impl EspPaths<10> for SystemdEspPaths {
             systemd: efi_systemd.clone(),
             systemd_boot: efi_systemd.join(architecture.systemd_filename()),
             loader,
+            entries,
             systemd_boot_loader_config,
         }
     }
@@ -52,7 +55,7 @@ impl EspPaths<10> for SystemdEspPaths {
         &self.linux
     }
 
-    fn iter(&self) -> std::array::IntoIter<&PathBuf, 10> {
+    fn iter(&self) -> std::array::IntoIter<&PathBuf, 11> {
         [
             &self.esp,
             &self.efi,
@@ -63,6 +66,7 @@ impl EspPaths<10> for SystemdEspPaths {
             &self.systemd,
             &self.systemd_boot,
             &self.loader,
+            &self.entries,
             &self.systemd_boot_loader_config,
         ]
         .into_iter()

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -237,25 +237,76 @@ impl Installer {
             .context("Failed to write os-release file.")?;
         let kernel_cmdline =
             assemble_kernel_cmdline(&bootspec.init, bootspec.kernel_params.clone());
-        let lanzaboote_image = pe::lanzaboote_image(
-            &tempdir,
-            &self.lanzaboote_stub,
-            &os_release_path,
-            &kernel_cmdline,
-            &bootspec.kernel,
-            &kernel_target,
-            &initrd_location,
-            &initrd_target,
-            &self.esp_paths.esp,
-        )
-        .context("Failed to assemble lanzaboote image.")?;
-        let stub_target = self
-            .esp_paths
-            .linux
-            .join(stub_name(generation, &self.key_pair.public_key)?);
-        self.gc_roots.extend([&stub_target]);
-        install_signed(&self.key_pair, &lanzaboote_image, &stub_target)
-            .context("Failed to install the Lanzaboote stub.")?;
+
+        if let Some(xen) = &generation.spec.xen_extension {
+            use std::fmt::Write;
+            let xen_image = pe::xen_image(
+                &tempdir,
+                &PathBuf::from(&xen.xen),
+                &xen.xen_params,
+                &kernel_cmdline,
+                &PathBuf::from(&xen.vmlinux),
+                &initrd_location,
+            )
+            .context("Failed to assemble xen image.")?;
+            let stub_target = self
+                .esp_paths
+                .linux
+                .join(stub_name(generation, &self.key_pair.public_key)?);
+            self.gc_roots.extend([&stub_target]);
+            install_signed(&self.key_pair, &xen_image, &stub_target)
+                .context("Failed to install the Lanzaboote image.")?;
+
+            // TODO: Currently xen doesn't work with specializations,
+            // and specialization name is not handled here, but this may
+            // be changed in the future.
+            let entry_path = self
+                .esp_paths
+                .entries
+                .join(format!("nixos-xen-{generation}.conf"));
+            self.gc_roots.extend([&entry_path]);
+
+            let mut entry = String::new();
+            writeln!(
+                entry,
+                "title {}",
+                os_release.0.get("PRETTY_NAME").expect("exists")
+            )?;
+            // stub_target should be utf-8, .display() is ok here.
+            // TODO: but better cleanup this. Use esp_relative_uefi_path
+            // for this calculation.
+            writeln!(
+                entry,
+                "efi {}",
+                stub_target.strip_prefix(&self.esp_paths.esp)?.display()
+            )?;
+
+            let entry_tmp = tempdir.write_secure_file(entry)?;
+
+            // Entry name is unique (with regards to comment about
+            // specialisations above).
+            install(&entry_tmp, &entry_path)?;
+        } else {
+            let lanzaboote_image = pe::lanzaboote_image(
+                &tempdir,
+                &self.lanzaboote_stub,
+                &os_release_path,
+                &kernel_cmdline,
+                &bootspec.kernel,
+                &kernel_target,
+                &initrd_location,
+                &initrd_target,
+                &self.esp_paths.esp,
+            )
+            .context("Failed to assemble lanzaboote image.")?;
+            let stub_target = self
+                .esp_paths
+                .linux
+                .join(stub_name(generation, &self.key_pair.public_key)?);
+            self.gc_roots.extend([&stub_target]);
+            install_signed(&self.key_pair, &lanzaboote_image, &stub_target)
+                .context("Failed to install the Lanzaboote stub.")?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/324911 implements Xen hypervisor support in NixOS, this PR implements Xen support in lanzaboote when used together with mentioned PR.

Current implementation produces very large EFI binaries (>160M, prepare your /boot partitions), because Xen can't verify linux image by itself, and it needs to be included in Xen unified kernel image (https://xenbits.xenproject.org/docs/unstable/misc/efi.html), which only supports unpacked (vmlinux) kernels (as far as I can see, using any other format (vmlinuz/bzImage) results in "Not an ELF binary" error).

Because there is no path to vmlinux image present in boot.json, extra configuration is required:
```nix
boot.bootspec.extensions."org.xenproject.bootspec.v1".vmlinux = "${config.system.build.kernel.dev}/vmlinux";
```

It is also impossible to have xen enabled for specialization, only primary system can have it, due to https://github.com/DeterminateSystems/bootspec/issues/147

Cc: @SigmaSquadron