### PR TITLE
chore(deps): update uefi to 0.31.0

### DIFF
--- a/rust/uefi/Cargo.lock
+++ b/rust/uefi/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c0a56dc9fed2589aad6ddca11c2584968fc21f227b5d7083bb8961d26a69fa"
+checksum = "920793ff1148ab68a07ab0b2b866870886cd1e5c0b1b94f451d66158d0ff1a77"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-macros"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a7b1c2c808c3db854a54d5215e3f7e7aaf5dcfbce095598cba6af29895695d"
+checksum = "b0732e421268a2d6d53c95c3c0f4496ccc5c08aa7381458c677153d5d77ce39e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa8716f52e8cab8bcedfd5052388a0f263b69fe5cc2561548dc6a530678333c"
+checksum = "7e537b93f83150df09588ca6658e881b2784e8b5f9588f1c7b72a85b72ea71ce"
 dependencies = [
  "bitflags",
  "ptr_meta",

--- a/rust/uefi/linux-bootloader/Cargo.toml
+++ b/rust/uefi/linux-bootloader/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/nix-community/lanzaboote/"
 rust-version = "1.68"
 
 [dependencies]
-uefi = { version = "0.28.0", default-features = false, features = [ "alloc", "global_allocator" ] }
+uefi = { version = "0.31.0", default-features = false, features = [ "alloc", "global_allocator" ] }
 # Update blocked by #237
 goblin = { version = "=0.6.1", default-features = false, features = [ "pe64", "alloc" ]}
 bitflags = "2.5.0"

--- a/rust/uefi/stub/Cargo.toml
+++ b/rust/uefi/stub/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-uefi = { version = "0.28.0", default-features = false, features = [ "alloc", "global_allocator", "panic_handler", "logger" ] }
+uefi = { version = "0.31.0", default-features = false, features = [ "alloc", "global_allocator", "panic_handler", "logger" ] }
 # Even in debug builds, we don't enable the debug logs, because they generate a lot of spam from goblin.
 log = { version = "0.4.21", default-features = false, features = [ "max_level_info", "release_max_level_warn" ]}
 # Use software implementation because the UEFI target seems to need it.

--- a/rust/uefi/stub/src/fat.rs
+++ b/rust/uefi/stub/src/fat.rs
@@ -41,11 +41,9 @@ impl EmbeddedConfiguration {
 
 pub fn boot_linux(
     handle: Handle,
-    mut system_table: SystemTable<Boot>,
+    system_table: SystemTable<Boot>,
     dynamic_initrds: Vec<Vec<u8>>,
 ) -> Status {
-    uefi::helpers::init(&mut system_table).unwrap();
-
     // SAFETY: We get a slice that represents our currently running
     // image and then parse the PE data structures from it. This is
     // safe, because we don't touch any data in the data sections that

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -45,8 +45,8 @@ fn print_logo() {
 }
 
 #[entry]
-fn main(handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
-    uefi::helpers::init(&mut system_table).unwrap();
+fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
+    uefi::helpers::init().unwrap();
 
     print_logo();
 

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -79,11 +79,9 @@ fn check_hash(data: &[u8], expected_hash: Hash, name: &str, secure_boot: bool) -
 
 pub fn boot_linux(
     handle: Handle,
-    mut system_table: SystemTable<Boot>,
+    system_table: SystemTable<Boot>,
     dynamic_initrds: Vec<Vec<u8>>,
 ) -> uefi::Result<()> {
-    uefi::helpers::init(&mut system_table).unwrap();
-
     // SAFETY: We get a slice that represents our currently running
     // image and then parse the PE data structures from it. This is
     // safe, because we don't touch any data in the data sections that


### PR DESCRIPTION
A few code changes were needed where the API has changed since 0.29.0:
* `uefi::helpers::init` no longer takes an argument.
* The `PcrEventInputs::new_in_buffer` API changed. In addition, there is now a `PcrEventInputs::new_in_box` constructor that allocates a correctly-sized buffer. Switch to that constructor.