### PR TITLE
Minor coding style fix: lib.getExe instead of ${bin}/bin/bin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
         # Derive the output overlay automatically from all packages that we define.
         inputs.flake-parts.flakeModules.easyOverlay
 
-        # Formatting and quality checks. 
+        # Formatting and quality checks.
       ] ++ (if inputs.pre-commit-hooks-nix ? flakeModule then [ inputs.pre-commit-hooks-nix.flakeModule ] else [ ]);
 
       flake.nixosModules.lanzaboote = moduleWithSystem (
@@ -174,6 +174,7 @@
           wrappedTool = pkgs.runCommand "lzbt"
             {
               nativeBuildInputs = [ pkgs.makeWrapper ];
+              meta.mainProgram = "lzbt";
             } ''
             mkdir -p $out/bin
 

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -126,12 +126,12 @@ in
         ${optionalString cfg.enrollKeys ''
           mkdir -p /tmp/pki
           cp -r ${cfg.pkiBundle}/* /tmp/pki
-          ${sbctlWithPki}/bin/sbctl enroll-keys --yes-this-might-brick-my-machine
+          ${lib.getExe sbctlWithPki} enroll-keys --yes-this-might-brick-my-machine
         ''}
 
         # Use the system from the kernel's hostPlatform because this should
         # always, even in the cross compilation case, be the right system.
-        ${cfg.package}/bin/lzbt install \
+        ${lib.getExe cfg.package} install \
           --system ${config.boot.kernelPackages.stdenv.hostPlatform.system} \
           --systemd ${config.systemd.package} \
           --systemd-boot-loader-config ${loaderConfigFile} \
@@ -163,7 +163,7 @@ in
       # Place the fwupd efi files in /run and sign them
       script = ''
         ln -sf ${config.services.fwupd.package.fwupd-efi}/libexec/fwupd/efi/fwupd*.efi /run/fwupd-efi/
-        ${pkgs.sbsigntool}/bin/sbsign --key '${cfg.privateKeyFile}' --cert '${cfg.publicKeyFile}' /run/fwupd-efi/fwupd*.efi
+        ${lib.getExe' pkgs.sbsigntool "sbsign"} --key '${cfg.privateKeyFile}' --cert '${cfg.publicKeyFile}' /run/fwupd-efi/fwupd*.efi
       '';
     };
 

--- a/nix/modules/uki.nix
+++ b/nix/modules/uki.nix
@@ -48,7 +48,7 @@ in
             '';
           };
         in
-        "${installer}/bin/install-uki";
+        "${lib.getExe installer}";
     };
   };
 }


### PR DESCRIPTION
This is a minor change in coding style that removes path references replacing them with `lib.getExe`.
This makes executable references less dependent on binary names.

Major advantage: the `cfg.package` option doesn't require the binary name to be "lzbt" anymore.