### PR TITLE
Replace uses of the RuntimeServices struct

### DIFF
--- a/rust/uefi/stub/src/common.rs
+++ b/rust/uefi/stub/src/common.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use log::warn;
 use uefi::{
-    guid, prelude::*, proto::loaded_image::LoadedImage, table::runtime::VariableVendor, CStr16,
+    guid, prelude::*, proto::loaded_image::LoadedImage, runtime, runtime::VariableVendor, CStr16,
     CString16, Result,
 };
 
@@ -43,35 +43,33 @@ pub fn get_cmdline(
 /// Check whether Secure Boot is active, and we should be enforcing integrity checks.
 ///
 /// In case of doubt, true is returned to be on the safe side.
-pub fn get_secure_boot_status(runtime_services: &RuntimeServices) -> bool {
+pub fn get_secure_boot_status() -> bool {
     // The firmware initialized SecureBoot to 1 if performing signature checks, and 0 if it doesn't.
     // Applications are not supposed to modify this variable (in particular, don't change the value from 1 to 0).
-    let secure_boot_enabled = runtime_services
-        .get_variable(
-            cstr16!("SecureBoot"),
-            &VariableVendor(guid!("8be4df61-93ca-11d2-aa0d-00e098032b8c")),
-            &mut [1],
-        )
-        .and_then(|(value, _)| match value {
-            [0] => Ok(false),
-            [1] => Ok(true),
-            [v] => {
-                warn!(
-                    "Unexpected value of SecureBoot variable: {v}. Performing verification anyway."
-                );
-                Ok(true)
-            }
-            _ => Err(Status::BAD_BUFFER_SIZE.into()),
-        })
-        .unwrap_or_else(|err| {
-            if err.status() == Status::NOT_FOUND {
-                warn!("SecureBoot variable not found. Assuming Secure Boot is not supported.");
-                false
-            } else {
-                warn!("Failed to read SecureBoot variable: {err}. Performing verification anyway.");
-                true
-            }
-        });
+    let secure_boot_enabled = runtime::get_variable(
+        cstr16!("SecureBoot"),
+        &VariableVendor(guid!("8be4df61-93ca-11d2-aa0d-00e098032b8c")),
+        &mut [1],
+    )
+    .discard_errdata()
+    .and_then(|(value, _)| match value {
+        [0] => Ok(false),
+        [1] => Ok(true),
+        [v] => {
+            warn!("Unexpected value of SecureBoot variable: {v}. Performing verification anyway.");
+            Ok(true)
+        }
+        _ => Err(Status::BAD_BUFFER_SIZE.into()),
+    })
+    .unwrap_or_else(|err| {
+        if err.status() == Status::NOT_FOUND {
+            warn!("SecureBoot variable not found. Assuming Secure Boot is not supported.");
+            false
+        } else {
+            warn!("Failed to read SecureBoot variable: {err}. Performing verification anyway.");
+            true
+        }
+    });
 
     if !secure_boot_enabled {
         warn!("Secure Boot is not active!");

--- a/rust/uefi/stub/src/fat.rs
+++ b/rust/uefi/stub/src/fat.rs
@@ -57,7 +57,7 @@ pub fn boot_linux(
         .expect("Failed to extract configuration from binary.")
     };
 
-    let secure_boot_enabled = get_secure_boot_status(system_table.runtime_services());
+    let secure_boot_enabled = get_secure_boot_status();
     let cmdline = get_cmdline(
         &config.cmdline,
         system_table.boot_services(),

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -63,7 +63,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
         let _ = measure_image(&system_table, &pe_in_memory);
     }
 
-    if let Ok(features) = get_loader_features(system_table.runtime_services()) {
+    if let Ok(features) = get_loader_features() {
         if !features.contains(EfiLoaderFeatures::RandomSeed) {
             // FIXME: process random seed then on the disk.
             info!("Random seed is available, but lanzaboote does not support it yet.");

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -95,7 +95,7 @@ pub fn boot_linux(
         .expect("Failed to extract configuration from binary. Did you run lzbt?")
     };
 
-    let secure_boot_enabled = get_secure_boot_status(system_table.runtime_services());
+    let secure_boot_enabled = get_secure_boot_status();
 
     let kernel_data;
     let mut initrd_data;


### PR DESCRIPTION
uefi-rs is transitioning away from explicit `BootServices` and `RuntimeServices` structs, plain functions will be used instead. See https://github.com/rust-osdev/uefi-rs/blob/main/docs/funcs_migration.md for more details.

To keep the review more manageable, this PR only updates uses of `RuntimeServices`; I'll follow up with PRs for `BootServices`.