### PR TITLE
Drop most uses of `BootServices`

### DIFF
--- a/rust/uefi/linux-bootloader/src/efivars.rs
+++ b/rust/uefi/linux-bootloader/src/efivars.rs
@@ -166,7 +166,7 @@ pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boo
 
     let stub_features: EfiStubFeatures = EfiStubFeatures::ReportBootPartition;
 
-    let loaded_image = boot_services.open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
+    let loaded_image = boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
 
     let default_attributes =
         VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS;
@@ -194,8 +194,8 @@ pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boo
         default_attributes,
         || {
             if let Some(dp) = loaded_image.file_path() {
-                let dp_protocol = boot_services.open_protocol_exclusive::<DevicePathToText>(
-                    boot_services.get_handle_for_protocol::<DevicePathToText>()?,
+                let dp_protocol = boot::open_protocol_exclusive::<DevicePathToText>(
+                    boot::get_handle_for_protocol::<DevicePathToText>()?,
                 )?;
                 dp_protocol
                     .convert_device_path_to_text(

--- a/rust/uefi/linux-bootloader/src/efivars.rs
+++ b/rust/uefi/linux-bootloader/src/efivars.rs
@@ -1,7 +1,7 @@
 use alloc::{format, string::ToString, vec::Vec};
 use core::mem::size_of;
 use uefi::{
-    cstr16, guid,
+    boot, cstr16, guid,
     prelude::BootServices,
     proto::{
         device_path::{
@@ -167,8 +167,7 @@ pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boo
 
     let stub_features: EfiStubFeatures = EfiStubFeatures::ReportBootPartition;
 
-    let loaded_image =
-        boot_services.open_protocol_exclusive::<LoadedImage>(boot_services.image_handle())?;
+    let loaded_image = boot_services.open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
 
     let default_attributes =
         VariableAttributes::BOOTSERVICE_ACCESS | VariableAttributes::RUNTIME_ACCESS;

--- a/rust/uefi/linux-bootloader/src/efivars.rs
+++ b/rust/uefi/linux-bootloader/src/efivars.rs
@@ -11,6 +11,7 @@ use uefi::{
         loaded_image::LoadedImage,
     },
     runtime::{self, VariableAttributes, VariableVendor},
+    table,
     table::{Boot, SystemTable},
     CStr16, Guid, Handle, Result, Status,
 };
@@ -162,8 +163,6 @@ where
 
 /// Exports systemd-stub style EFI variables
 pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boot>) -> Result<()> {
-    let boot_services = system_table.boot_services();
-
     let stub_features: EfiStubFeatures = EfiStubFeatures::ReportBootPartition;
 
     let loaded_image = boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
@@ -199,7 +198,7 @@ pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boo
                 )?;
                 dp_protocol
                     .convert_device_path_to_text(
-                        boot_services,
+                        table::system_table_boot().unwrap().boot_services(),
                         dp,
                         uefi::proto::device_path::text::DisplayOnly(false),
                         uefi::proto::device_path::text::AllowShortcuts(false),

--- a/rust/uefi/linux-bootloader/src/uefi_helpers.rs
+++ b/rust/uefi/linux-bootloader/src/uefi_helpers.rs
@@ -1,6 +1,7 @@
 use core::ffi::c_void;
 
 use uefi::{
+    boot,
     prelude::BootServices,
     proto::{
         device_path::{DevicePath, FfiDevicePath},
@@ -51,8 +52,7 @@ impl PeInMemory {
 
 /// Open the currently executing image as a file.
 pub fn booted_image_file(boot_services: &BootServices) -> Result<PeInMemory> {
-    let loaded_image =
-        boot_services.open_protocol_exclusive::<LoadedImage>(boot_services.image_handle())?;
+    let loaded_image = boot_services.open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
     let (image_base, image_size) = loaded_image.info();
 
     Ok(PeInMemory {

--- a/rust/uefi/linux-bootloader/src/uefi_helpers.rs
+++ b/rust/uefi/linux-bootloader/src/uefi_helpers.rs
@@ -2,7 +2,6 @@ use core::ffi::c_void;
 
 use uefi::{
     boot,
-    prelude::BootServices,
     proto::{
         device_path::{DevicePath, FfiDevicePath},
         loaded_image::LoadedImage,
@@ -51,8 +50,8 @@ impl PeInMemory {
 }
 
 /// Open the currently executing image as a file.
-pub fn booted_image_file(boot_services: &BootServices) -> Result<PeInMemory> {
-    let loaded_image = boot_services.open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
+pub fn booted_image_file() -> Result<PeInMemory> {
+    let loaded_image = boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
     let (image_base, image_size) = loaded_image.info();
 
     Ok(PeInMemory {

--- a/rust/uefi/stub/src/common.rs
+++ b/rust/uefi/stub/src/common.rs
@@ -84,8 +84,7 @@ pub fn boot_linux_unchecked(
     kernel_cmdline: &[u8],
     initrd_data: Vec<u8>,
 ) -> uefi::Result<()> {
-    let kernel =
-        Image::load(system_table.boot_services(), &kernel_data).expect("Failed to load the kernel");
+    let kernel = Image::load(&kernel_data).expect("Failed to load the kernel");
 
     let mut initrd_loader = InitrdLoader::new(handle, initrd_data)?;
 

--- a/rust/uefi/stub/src/common.rs
+++ b/rust/uefi/stub/src/common.rs
@@ -1,8 +1,8 @@
 use alloc::vec::Vec;
 use log::warn;
 use uefi::{
-    guid, prelude::*, proto::loaded_image::LoadedImage, runtime, runtime::VariableVendor, CStr16,
-    CString16, Result,
+    boot, guid, prelude::*, proto::loaded_image::LoadedImage, runtime, runtime::VariableVendor,
+    CStr16, CString16, Result,
 };
 
 use linux_bootloader::linux_loader::InitrdLoader;
@@ -30,7 +30,7 @@ pub fn get_cmdline(
         embedded.as_bytes().to_vec()
     } else {
         let passed = boot_services
-            .open_protocol_exclusive::<LoadedImage>(boot_services.image_handle())
+            .open_protocol_exclusive::<LoadedImage>(boot::image_handle())
             .map(|loaded_image| loaded_image.load_options_as_bytes().map(|b| b.to_vec()));
         match passed {
             Ok(Some(passed)) => passed,

--- a/rust/uefi/stub/src/common.rs
+++ b/rust/uefi/stub/src/common.rs
@@ -20,17 +20,12 @@ pub fn extract_string(pe_data: &[u8], section: &str) -> Result<CString16> {
 ///
 /// If Secure Boot is active, this is always the embedded one (since the one passed from the bootloader may come from a malicious type 1 entry).
 /// If Secure Boot is not active, the command line passed from the bootloader is used, falling back to the embedded one.
-pub fn get_cmdline(
-    embedded: &CStr16,
-    boot_services: &BootServices,
-    secure_boot_enabled: bool,
-) -> Vec<u8> {
+pub fn get_cmdline(embedded: &CStr16, secure_boot_enabled: bool) -> Vec<u8> {
     if secure_boot_enabled {
         // The command line passed from the bootloader cannot be trusted, so it is not used when Secure Boot is active.
         embedded.as_bytes().to_vec()
     } else {
-        let passed = boot_services
-            .open_protocol_exclusive::<LoadedImage>(boot::image_handle())
+        let passed = boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())
             .map(|loaded_image| loaded_image.load_options_as_bytes().map(|b| b.to_vec()));
         match passed {
             Ok(Some(passed)) => passed,

--- a/rust/uefi/stub/src/common.rs
+++ b/rust/uefi/stub/src/common.rs
@@ -87,10 +87,10 @@ pub fn boot_linux_unchecked(
     let kernel =
         Image::load(system_table.boot_services(), &kernel_data).expect("Failed to load the kernel");
 
-    let mut initrd_loader = InitrdLoader::new(system_table.boot_services(), handle, initrd_data)?;
+    let mut initrd_loader = InitrdLoader::new(handle, initrd_data)?;
 
     let status = unsafe { kernel.start(handle, &system_table, kernel_cmdline) };
 
-    initrd_loader.uninstall(system_table.boot_services())?;
+    initrd_loader.uninstall()?;
     status.to_result()
 }

--- a/rust/uefi/stub/src/fat.rs
+++ b/rust/uefi/stub/src/fat.rs
@@ -49,12 +49,8 @@ pub fn boot_linux(
     // safe, because we don't touch any data in the data sections that
     // might conceivably change while we look at the slice.
     let mut config = unsafe {
-        EmbeddedConfiguration::new(
-            booted_image_file(system_table.boot_services())
-                .unwrap()
-                .as_slice(),
-        )
-        .expect("Failed to extract configuration from binary.")
+        EmbeddedConfiguration::new(booted_image_file().unwrap().as_slice())
+            .expect("Failed to extract configuration from binary.")
     };
 
     let secure_boot_enabled = get_secure_boot_status();

--- a/rust/uefi/stub/src/fat.rs
+++ b/rust/uefi/stub/src/fat.rs
@@ -58,11 +58,7 @@ pub fn boot_linux(
     };
 
     let secure_boot_enabled = get_secure_boot_status();
-    let cmdline = get_cmdline(
-        &config.cmdline,
-        system_table.boot_services(),
-        secure_boot_enabled,
-    );
+    let cmdline = get_cmdline(&config.cmdline, secure_boot_enabled);
 
     let mut final_initrd = Vec::new();
     final_initrd.append(&mut config.initrd);

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -94,11 +94,8 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
             let default_dropin_directory;
 
             if let Some(loaded_image_path) = pe_in_memory.file_path() {
-                let discovered_default_dropin_dir = get_default_dropin_directory(
-                    system_table.boot_services(),
-                    loaded_image_path,
-                    &mut filesystem,
-                );
+                let discovered_default_dropin_dir =
+                    get_default_dropin_directory(loaded_image_path, &mut filesystem);
 
                 if discovered_default_dropin_dir.is_err() {
                     warn!("Failed to discover the default drop-in directory for companion files");

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -52,7 +52,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
     print_logo();
 
     let is_tpm_available = tpm_available();
-    let pe_in_memory = booted_image_file(system_table.boot_services())
+    let pe_in_memory = booted_image_file()
         .expect("Failed to extract the in-memory information about our own image");
 
     if is_tpm_available {

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -24,6 +24,7 @@ use linux_bootloader::measure::{measure_companion_initrds, measure_image};
 use linux_bootloader::tpm::tpm_available;
 use linux_bootloader::uefi_helpers::booted_image_file;
 use log::{info, warn};
+use uefi::boot;
 use uefi::prelude::*;
 
 /// Lanzaboote stub name
@@ -86,7 +87,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
         let mut companions = Vec::new();
         let image_fs = system_table
             .boot_services()
-            .get_image_file_system(system_table.boot_services().image_handle());
+            .get_image_file_system(boot::image_handle());
 
         if let Ok(image_fs) = image_fs {
             let mut filesystem = uefi::fs::FileSystem::new(image_fs);

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -51,7 +51,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
 
     print_logo();
 
-    let is_tpm_available = tpm_available(system_table.boot_services());
+    let is_tpm_available = tpm_available();
     let pe_in_memory = booted_image_file(system_table.boot_services())
         .expect("Failed to extract the in-memory information about our own image");
 
@@ -61,7 +61,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
         // For now, ignore failures during measurements.
         // TODO: in the future, devise a threat model where this can fail
         // and ensure this hard-fail correctly.
-        let _ = measure_image(&system_table, &pe_in_memory);
+        let _ = measure_image(&pe_in_memory);
     }
 
     if let Ok(features) = get_loader_features() {
@@ -132,7 +132,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
             if is_tpm_available {
                 // TODO: in the future, devise a threat model where this can fail, see above
                 // measurements to understand the context.
-                let _ = measure_companion_initrds(&system_table, &companions);
+                let _ = measure_companion_initrds(&companions);
             }
 
             dynamic_initrds.append(

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -87,12 +87,8 @@ pub fn boot_linux(
     // safe, because we don't touch any data in the data sections that
     // might conceivably change while we look at the slice.
     let config = unsafe {
-        EmbeddedConfiguration::new(
-            booted_image_file(system_table.boot_services())
-                .unwrap()
-                .as_slice(),
-        )
-        .expect("Failed to extract configuration from binary. Did you run lzbt?")
+        EmbeddedConfiguration::new(booted_image_file().unwrap().as_slice())
+            .expect("Failed to extract configuration from binary. Did you run lzbt?")
     };
 
     let secure_boot_enabled = get_secure_boot_status();

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -115,11 +115,7 @@ pub fn boot_linux(
             .expect("Failed to read initrd file into memory");
     }
 
-    let cmdline = get_cmdline(
-        &config.cmdline,
-        system_table.boot_services(),
-        secure_boot_enabled,
-    );
+    let cmdline = get_cmdline(&config.cmdline, secure_boot_enabled);
 
     check_hash(
         &kernel_data,


### PR DESCRIPTION
Continuing the migration from previous PRs, clean up most uses of `BootServices` and `boot_services()`. In a couple place it's still needed for the uefi-0.31 API; those can be cleaned up when updating to uefi-0.32.