### PR TITLE
Drop most uses of `SystemTable`

### DIFF
--- a/rust/uefi/linux-bootloader/src/efivars.rs
+++ b/rust/uefi/linux-bootloader/src/efivars.rs
@@ -11,9 +11,7 @@ use uefi::{
         loaded_image::LoadedImage,
     },
     runtime::{self, VariableAttributes, VariableVendor},
-    table,
-    table::{Boot, SystemTable},
-    CStr16, Guid, Handle, Result, Status,
+    system, table, CStr16, Guid, Handle, Result, Status,
 };
 
 use bitflags::bitflags;
@@ -162,7 +160,7 @@ where
 }
 
 /// Exports systemd-stub style EFI variables
-pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boot>) -> Result<()> {
+pub fn export_efi_variables(stub_info_name: &str) -> Result<()> {
     let stub_features: EfiStubFeatures = EfiStubFeatures::ReportBootPartition;
 
     let loaded_image = boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
@@ -220,9 +218,9 @@ pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boo
         || {
             Ok(format!(
                 "{} {}.{:02}",
-                system_table.firmware_vendor(),
-                system_table.firmware_revision() >> 16,
-                system_table.firmware_revision() & 0xFFFFF
+                system::firmware_vendor(),
+                system::firmware_revision() >> 16,
+                system::firmware_revision() & 0xFFFFF
             )
             .encode_utf16()
             .flat_map(|c| c.to_le_bytes())
@@ -236,7 +234,7 @@ pub fn export_efi_variables(stub_info_name: &str, system_table: &SystemTable<Boo
         &BOOT_LOADER_VENDOR_UUID,
         default_attributes,
         || {
-            Ok(format!("UEFI {:02}", system_table.uefi_revision())
+            Ok(format!("UEFI {:02}", system::uefi_revision())
                 .encode_utf16()
                 .flat_map(|c| c.to_le_bytes())
                 .collect::<Vec<u8>>())

--- a/rust/uefi/stub/src/common.rs
+++ b/rust/uefi/stub/src/common.rs
@@ -79,7 +79,6 @@ pub fn get_secure_boot_status() -> bool {
 /// be loaded using other means.
 pub fn boot_linux_unchecked(
     handle: Handle,
-    system_table: SystemTable<Boot>,
     kernel_data: Vec<u8>,
     kernel_cmdline: &[u8],
     initrd_data: Vec<u8>,
@@ -88,7 +87,7 @@ pub fn boot_linux_unchecked(
 
     let mut initrd_loader = InitrdLoader::new(handle, initrd_data)?;
 
-    let status = unsafe { kernel.start(handle, &system_table, kernel_cmdline) };
+    let status = unsafe { kernel.start(handle, kernel_cmdline) };
 
     initrd_loader.uninstall()?;
     status.to_result()

--- a/rust/uefi/stub/src/fat.rs
+++ b/rust/uefi/stub/src/fat.rs
@@ -39,11 +39,7 @@ impl EmbeddedConfiguration {
     }
 }
 
-pub fn boot_linux(
-    handle: Handle,
-    system_table: SystemTable<Boot>,
-    dynamic_initrds: Vec<Vec<u8>>,
-) -> Status {
+pub fn boot_linux(handle: Handle, dynamic_initrds: Vec<Vec<u8>>) -> Status {
     // SAFETY: We get a slice that represents our currently running
     // image and then parse the PE data structures from it. This is
     // safe, because we don't touch any data in the data sections that
@@ -67,5 +63,5 @@ pub fn boot_linux(
         final_initrd.append(&mut extra_initrd);
     }
 
-    boot_linux_unchecked(handle, system_table, config.kernel, &cmdline, final_initrd).status()
+    boot_linux_unchecked(handle, config.kernel, &cmdline, final_initrd).status()
 }

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -150,7 +150,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
 
     #[cfg(feature = "thin")]
     {
-        status = thin::boot_linux(handle, system_table, dynamic_initrds).status()
+        status = thin::boot_linux(handle, dynamic_initrds).status()
     }
 
     status

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -145,7 +145,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
 
     #[cfg(feature = "fat")]
     {
-        status = fat::boot_linux(handle, system_table, dynamic_initrds)
+        status = fat::boot_linux(handle, dynamic_initrds)
     }
 
     #[cfg(feature = "thin")]

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -71,7 +71,7 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
         }
     }
 
-    if export_efi_variables(STUB_NAME, &system_table).is_err() {
+    if export_efi_variables(STUB_NAME).is_err() {
         warn!("Failed to export stub EFI variables, some features related to measured boot will not be available");
     }
 

--- a/rust/uefi/stub/src/main.rs
+++ b/rust/uefi/stub/src/main.rs
@@ -46,7 +46,7 @@ fn print_logo() {
 }
 
 #[entry]
-fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
+fn main() -> Status {
     uefi::helpers::init().unwrap();
 
     print_logo();
@@ -145,12 +145,12 @@ fn main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
 
     #[cfg(feature = "fat")]
     {
-        status = fat::boot_linux(handle, dynamic_initrds)
+        status = fat::boot_linux(boot::image_handle(), dynamic_initrds)
     }
 
     #[cfg(feature = "thin")]
     {
-        status = thin::boot_linux(handle, dynamic_initrds).status()
+        status = thin::boot_linux(boot::image_handle(), dynamic_initrds).status()
     }
 
     status

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use log::{error, warn};
 use sha2::{Digest, Sha256};
-use uefi::{fs::FileSystem, prelude::*, CString16, Result};
+use uefi::{fs::FileSystem, prelude::*, table, CString16, Result};
 
 use crate::common::{boot_linux_unchecked, extract_string, get_cmdline, get_secure_boot_status};
 use linux_bootloader::pe_section::pe_section;
@@ -77,11 +77,7 @@ fn check_hash(data: &[u8], expected_hash: Hash, name: &str, secure_boot: bool) -
     Ok(())
 }
 
-pub fn boot_linux(
-    handle: Handle,
-    system_table: SystemTable<Boot>,
-    dynamic_initrds: Vec<Vec<u8>>,
-) -> uefi::Result<()> {
+pub fn boot_linux(handle: Handle, dynamic_initrds: Vec<Vec<u8>>) -> uefi::Result<()> {
     // SAFETY: We get a slice that represents our currently running
     // image and then parse the PE data structures from it. This is
     // safe, because we don't touch any data in the data sections that
@@ -97,6 +93,7 @@ pub fn boot_linux(
     let mut initrd_data;
 
     {
+        let system_table = table::system_table_boot().unwrap();
         let file_system = system_table
             .boot_services()
             .get_image_file_system(handle)

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -147,5 +147,5 @@ pub fn boot_linux(
         initrd_data.append(&mut compute_pad4(initrd_data.len()));
     }
 
-    boot_linux_unchecked(handle, system_table, kernel_data, &cmdline, initrd_data)
+    boot_linux_unchecked(handle, kernel_data, &cmdline, initrd_data)
 }


### PR DESCRIPTION
Continuing to smooth the way for updating to uefi-0.32.