### PR TITLE
.github: add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: "Run nix flake check"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          diagnostic-endpoint: ""
+          source-url: "https://install.lix.systems/lix/lix-installer-x86_64-linux"
+      - run: nix-shell -p nix-fast-build --run "nix-fast-build --skip-cached --no-nom"
+
+env:
+  FORCE_COLOR: 1


### PR DESCRIPTION
As our buildbot CI is failing intermittently, let's try out GitHub Actions concurrently and see if that works better.