### PR TITLE
Add keepCurrentBootedConfiguration option

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -60,6 +60,8 @@ in
       '';
     };
 
+    keepCurrentBootedConfiguration = lib.mkEnableOption "keeping the current booted configuration (labeled 'SAFE' in boot menu)";
+
     pkiBundle = lib.mkOption {
       type = lib.types.nullOr lib.types.externalPath;
       description = "PKI bundle containing db, PK, KEK";
@@ -170,7 +172,7 @@ in
           --systemd-boot-loader-config ${loaderConfigFile} \
           --configuration-limit ${toString configurationLimit} \
           --allow-unsigned ${lib.boolToString cfg.allowUnsigned} \
-          --bootcounting-initial-tries ${toString cfg.bootCounting.initialTries}'';
+          --bootcounting-initial-tries ${toString cfg.bootCounting.initialTries}${lib.optionalString cfg.keepCurrentBootedConfiguration " \\\n  --safe-generation /run/booted-system"}'';
       defaultText = lib.literalExpression ''
         ''${lib.getExe config.boot.lanzaboote.package} install \
           --system ''${config.boot.kernelPackages.stdenv.hostPlatform.system} \
@@ -178,7 +180,7 @@ in
           --systemd-boot-loader-config ''${loaderConfigFile} \
           --configuration-limit ''${toString configurationLimit} \
           --allow-unsigned ''${lib.boolToString config.boot.lanzaboote.allowUnsigned} \
-          --bootcounting-initial-tries ''${toString config.boot.lanzaboote.bootCounting.initialTries}'';
+          --bootcounting-initial-tries ''${toString config.boot.lanzaboote.bootCounting.initialTries}''${lib.optionalString config.boot.lanzaboote.keepCurrentBootedConfiguration " \\\n --safe-generation /run/booted-system"}'';
     };
 
     extraEfiSysMountPoints = lib.mkOption {

--- a/rust/tool/systemd/src/cli.rs
+++ b/rust/tool/systemd/src/cli.rs
@@ -70,6 +70,10 @@ struct InstallCommand {
 
     /// List of generation links (e.g. /nix/var/nix/profiles/system-*-link)
     generations: Vec<PathBuf>,
+
+    /// A safe generation (usually /run/booted-system) that should always be kept, ignored from --configuration-limit if used
+    #[arg(long)]
+    safe_generation: Option<PathBuf>,
 }
 
 impl Cli {
@@ -113,6 +117,7 @@ fn install(args: InstallCommand) -> Result<()> {
         args.bootcounting_initial_tries,
         args.esp,
         args.generations,
+        args.safe_generation,
     );
 
     if args.allow_unsigned

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -33,6 +33,7 @@ pub struct InstallerBuilder {
     bootcounting_initial_tries: u32,
     esp: PathBuf,
     generation_links: Vec<PathBuf>,
+    safe_generation: Option<PathBuf>,
 }
 
 impl InstallerBuilder {
@@ -46,6 +47,7 @@ impl InstallerBuilder {
         bootcounting_initial_tries: u32,
         esp: PathBuf,
         generation_links: Vec<PathBuf>,
+        safe_generation: Option<PathBuf>,
     ) -> Self {
         Self {
             lanzaboote_stub: lanzaboote_stub.as_ref().to_path_buf(),
@@ -56,6 +58,7 @@ impl InstallerBuilder {
             bootcounting_initial_tries,
             esp,
             generation_links,
+            safe_generation,
         }
     }
 
@@ -75,6 +78,7 @@ impl InstallerBuilder {
             bootcounting_initial_tries: self.bootcounting_initial_tries,
             esp_paths,
             generation_links: self.generation_links,
+            safe_generation : self.safe_generation,
             arch: self.arch,
         }
     }
@@ -91,6 +95,7 @@ pub struct Installer<S: Signer> {
     bootcounting_initial_tries: u32,
     esp_paths: SystemdEspPaths,
     generation_links: Vec<PathBuf>,
+    safe_generation: Option<PathBuf>,
     arch: Architecture,
 }
 
@@ -102,6 +107,12 @@ impl<S: Signer> Installer<S> {
             .generation_links
             .iter()
             .map(GenerationLink::from_path)
+            .collect::<Result<Vec<GenerationLink>>>()?;
+
+        let mut all_links = self
+            .safe_generation
+            .iter()
+            .map(|p| GenerationLink::from_path_with_label(p, "SAFE".to_string()))
             .collect::<Result<Vec<GenerationLink>>>()?;
 
         // Sort the links by version, so that the limit actually skips the oldest generations.
@@ -118,9 +129,11 @@ impl<S: Signer> Installer<S> {
                 .rev()
                 .take(self.configuration_limit)
                 .rev()
-                .collect()
+                .collect();
         };
-        self.install_generations_from_links(&links)?;
+        all_links.append(&mut links);
+
+        self.install_generations_from_links(&all_links)?;
 
         self.install_systemd_boot()?;
 


### PR DESCRIPTION
 to always keep booted system configuration in boot menu.

it is mostly a prof of concept (this is my first time writing some rust code) so probably need some work.

This is a fix/workaround for https://github.com/NixOS/nixpkgs/issues/24158 / https://github.com/NixOS/nix/issues/1095 (only when using lanzaboote of course).