### PR TITLE
feat: enable support for `XBOOTLDR`

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -28,6 +28,11 @@ let
   ]
   ++ cfg.extraEfiSysMountPoints;
 
+  bootMountPoints = [
+    bootMountPoint
+  ]
+  ++ cfg.extraXbootldrMountPoints;
+  
   mkInstallCommand =
     efiSysMountPoint:
     ''
@@ -257,6 +262,15 @@ in
         List of EFI system partition mount points to install the bootloader to (additionally to boot.loader.efi.efiSysMountPoint).
       '';
       default = [ ];
+    };
+
+    extraXbootldrMountPoints = lib.mkOption {
+      type = lib.types.listOf (lib.types.nullOr lib.types.str);
+      description = ''
+        List of Extended Bootloader (XBOOTLDR) mount points to install the boot entries to, paired with each entries in `extraEfiSysMountPoints` (additionally to boot.loader.systemd-boot.xbootldrMountPoint).
+      '';
+      default = lib.genList (_: null) (lib.length cfg.extraEfiSysMountPoints);
+      defaultText = "[ null ] # repeated to match extraEfiSysMountPoints length";
     };
 
     allowUnsigned = lib.mkEnableOption "" // {

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -32,9 +32,9 @@ let
     bootMountPoint
   ]
   ++ cfg.extraXbootldrMountPoints;
-  
+
   mkInstallCommand =
-    efiSysMountPoint:
+    espAndBootMountPoint:
     ''
       PATH=${config.systemd.package}/lib/systemd:$PATH
       ${cfg.installCommand} \
@@ -49,7 +49,10 @@ let
           "--pcrlock-directory=${cfg.measuredBoot.pcrlockDirectory}"
         ]
         ++ [
-          efiSysMountPoint
+          espAndBootMountPoint.esp
+        ]
+        ++ [
+          (if espAndBootMountPoint.boot == null then espAndBootMountPoint.esp else espAndBootMountPoint.boot)
         ]
       )
       + " /nix/var/nix/profiles/system-*-link"
@@ -57,7 +60,14 @@ let
 
   installHook = pkgs.writeShellScriptBin "lzbt" (
     ''
-      ${lib.concatStringsSep "\n" (map mkInstallCommand efiSysMountPoints)}
+      ${lib.concatStringsSep "\n" (
+        map mkInstallCommand (
+          lib.zipListsWith (a: b: {
+            esp = a;
+            boot = b;
+          }) efiSysMountPoints bootMountPoints
+        )
+      )}
     ''
     + lib.optionalString cfg.measuredBoot.enable ''
       echo "Predicting the PCR state for future boots..."

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -9,6 +9,12 @@ let
   cfg = config.boot.lanzaboote;
   espMountPoint = config.boot.loader.efi.efiSysMountPoint;
 
+  bootMountPoint =
+    if config.boot.loader.systemd-boot.xbootldrMountPoint != null then
+      config.boot.loader.systemd-boot.xbootldrMountPoint
+    else
+      config.boot.loader.efi.efiSysMountPoint;
+
   loaderSettingsFormat = pkgs.formats.keyValue {
     mkKeyValue = k: v: if v == null then "" else lib.generators.mkKeyValueDefault { } " " k v;
   };

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -29,6 +29,7 @@ in
   boot-counting = runTest ./lanzaboote/boot-counting.nix;
   measured-boot = runTest ./lanzaboote/measured-boot.nix;
   auto-reboot = runTest ./lanzaboote/auto-reboot.nix;
+  xbootldr = runTest ./lanzaboote/xbootldr.nix;
 
   systemd-pcrlock = runTest ./lanzaboote/systemd-pcrlock.nix;
   systemd-measure = runTest ./lanzaboote/systemd-measure.nix;

--- a/nix/tests/lanzaboote/common/image.nix
+++ b/nix/tests/lanzaboote/common/image.nix
@@ -7,6 +7,7 @@
 }:
 let
   espLabel = "esp";
+  xbootldrLabel = "xbootldr";
   nixStorePartitionLabel = "nix-store";
   rootPartitionLabel = "root";
 
@@ -29,8 +30,17 @@ let
     '';
 
   espFiles = pkgs.runCommand "esp-files" { } (
-    ''
-      mkdir -p $out
+    (
+      if config.lanzabooteTest.xbootldr then
+        ''
+          mkdir -p $out/esp $out/xbootldr
+        ''
+      else
+        ''
+          mkdir -p $out
+        ''
+    )
+    + ''
       ln -s ${config.system.build.toplevel} system-1-link
       ${cfg.installCommand} \
     ''
@@ -48,8 +58,19 @@ let
           --private-key ${cfg.privateKeyFile} \
         ''
     )
+    + (
+      if config.lanzabooteTest.xbootldr then
+        ''
+          $out/esp \
+          $out/xbootldr \
+        ''
+      else
+        ''
+          $out \
+          $out \
+        ''
+    )
     + ''
-      $out \
       system-1-link
     ''
   );
@@ -75,36 +96,46 @@ in
 {
   imports = [ "${modulesPath}/image/repart.nix" ];
 
-  fileSystems = {
-    "/boot" = {
-      device = "/dev/disk/by-partlabel/${espLabel}";
-      fsType = "vfat";
-      options = [ "umask=077" ];
+  fileSystems =
+    let
+      esp = {
+        device = "/dev/disk/by-partlabel/${espLabel}";
+        fsType = "vfat";
+        options = [ "umask=077" ];
+      };
+      xbootldr = {
+        device = "/dev/disk/by-partlabel/${xbootldrLabel}";
+        fsType = "vfat";
+        options = [ "umask=077" ];
+      };
+    in
+    {
+      "/boot" = if config.lanzabooteTest.xbootldr then xbootldr else esp;
+      "/" =
+        if config.lanzabooteTest.persistentRoot then
+          {
+            device = "/dev/disk/by-partlabel/${rootPartitionLabel}";
+            fsType = "ext4";
+          }
+        else
+          {
+            fsType = "tmpfs";
+            options = [ "mode=755" ];
+          };
+      "/nix/store" = {
+        device = "/dev/disk/by-partlabel/${nixStorePartitionLabel}";
+        fsType = "erofs";
+        options = [ "ro" ];
+      };
+    }
+    // lib.optionalAttrs config.lanzabooteTest.xbootldr {
+      "/efi" = esp;
     };
-    "/" =
-      if config.lanzabooteTest.persistentRoot then
-        {
-          device = "/dev/disk/by-partlabel/${rootPartitionLabel}";
-          fsType = "ext4";
-        }
-      else
-        {
-          fsType = "tmpfs";
-          options = [ "mode=755" ];
-        };
-    "/nix/store" = {
-      device = "/dev/disk/by-partlabel/${nixStorePartitionLabel}";
-      fsType = "erofs";
-      options = [ "ro" ];
-    };
-  };
 
   system.image = {
     id = config.system.name;
     version = config.system.nixos.version;
   };
-
-  system.build.espFiles = espFiles;
 
   image.repart = {
     name = config.system.name;
@@ -115,7 +146,7 @@ in
     partitions = {
       "esp" = {
         contents = {
-          "/".source = espFiles;
+          "/".source = if config.lanzabooteTest.xbootldr then "${espFiles}/esp" else espFiles;
         }
         // lib.optionalAttrs config.lanzabooteTest.keyFixture {
           "/loader/keys/auto/PK.auth".source = "${authVariables}/PK.auth";
@@ -124,7 +155,11 @@ in
         };
         repartConfig = {
           Type = "esp";
-          Format = config.fileSystems."/boot".fsType;
+          Format =
+            if config.lanzabooteTest.xbootldr then
+              config.fileSystems."/efi".fsType
+            else
+              config.fileSystems."/boot".fsType;
           Label = espLabel;
           SizeMinBytes = if config.nixpkgs.hostPlatform.isx86_64 then "64M" else "128M";
           UUID = "a3c9c5a1-1a9a-451c-bdac-a80bacb4170b";
@@ -151,6 +186,20 @@ in
           Format = config.fileSystems."/".fsType;
           Label = rootPartitionLabel;
           SizeMinBytes = "1M";
+        };
+      };
+    }
+    // lib.optionalAttrs config.lanzabooteTest.xbootldr {
+      "xbootldr" = {
+        contents = {
+          "/".source = "${espFiles}/xbootldr";
+        };
+        repartConfig = {
+          Type = "xbootldr";
+          Format = config.fileSystems."/boot".fsType;
+          Label = xbootldrLabel;
+          SizeMinBytes = if config.nixpkgs.hostPlatform.isx86_64 then "64M" else "96M";
+          UUID = "c0787616-512d-4e27-a487-5fba825e60a4";
         };
       };
     };

--- a/nix/tests/lanzaboote/common/lanzaboote.nix
+++ b/nix/tests/lanzaboote/common/lanzaboote.nix
@@ -12,6 +12,8 @@ in
     };
 
     persistentRoot = lib.mkEnableOption "a persistent root filesystem";
+
+    xbootldr = lib.mkEnableOption "a separate XBOOTLDR partition (as specified by UAPI)";
   };
 
   config = {

--- a/nix/tests/lanzaboote/xbootldr.nix
+++ b/nix/tests/lanzaboote/xbootldr.nix
@@ -1,0 +1,66 @@
+{
+
+  name = "lanzaboote-xbootldr";
+
+  nodes = {
+    machine1 = {
+      imports = [ ./common/lanzaboote.nix ];
+
+      lanzabooteTest = {
+        xbootldr = true;
+      };
+
+      boot = {
+        loader = {
+          systemd-boot.xbootldrMountPoint = "/boot";
+          efi.efiSysMountPoint = "/efi";
+        };
+      };
+    };
+    machine2 = {
+      imports = [ ./common/lanzaboote.nix ];
+
+      lanzabooteTest = {
+        xbootldr = true;
+      };
+
+      boot = {
+        loader = {
+          systemd-boot.xbootldrMountPoint = "/boot";
+          efi.efiSysMountPoint = "/efi";
+        };
+        lanzaboote = {
+          extraEfiSysMountPoints = [ "/efi2" ];
+          extraXbootldrMountPoints = [ "/boot2" ];
+        };
+      };
+      # We need this so switch-to-configuration exists and can set up /boot2
+      system.switch.enable = true;
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    (import ./common/image-helper.nix { machine = nodes.machine1; })
+    + (import ./common/image-helper.nix { machine = nodes.machine2; })
+    + ''
+      # Adapted from basic.nix
+      machine1_bootctl_status = machine1.succeed("bootctl status")
+      print(machine1_bootctl_status)
+      t.assertIn("Secure Boot: enabled (user)", machine1_bootctl_status)
+      t.assertIn("ESP: /efi", machine1_bootctl_status)
+      t.assertIn("XBOOTLDR: /boot", machine1_bootctl_status)
+      t.assertIn("Kernel Type: uki", machine1.succeed("bootctl kernel-inspect /boot/EFI/Linux/nixos-generation-1-*.efi"))
+
+      # Adapted from extra-efi-partitions.nix
+      machine2_bootctl_status = machine2.succeed("bootctl status")
+      print(machine2_bootctl_status)
+      t.assertIn("Secure Boot: enabled (user)", machine2_bootctl_status)
+      t.assertIn("ESP: /efi", machine2_bootctl_status)
+      t.assertIn("XBOOTLDR: /boot", machine2_bootctl_status)
+      machine2.succeed("mkdir -p /nix/var/nix/profiles && ln -s ${nodes.machine2.system.build.toplevel} /nix/var/nix/profiles/system-1-link")
+      machine2.succeed("/run/current-system/bin/switch-to-configuration boot")
+      t.assertIn("Kernel Type: uki", machine2.succeed("bootctl kernel-inspect /boot/EFI/Linux/nixos-generation-1-*.efi"))
+      t.assertIn("Kernel Type: uki", machine2.succeed("bootctl kernel-inspect /boot2/EFI/Linux/nixos-generation-1-*.efi"))
+    '';
+}

--- a/rust/tool/shared/src/esp.rs
+++ b/rust/tool/shared/src/esp.rs
@@ -5,7 +5,7 @@ use crate::architecture::Architecture;
 /// Generic ESP paths which can be specific to a bootloader
 pub trait EspPaths<const N: usize> {
     /// Build an ESP path structure out of the ESP root directory
-    fn new(esp: impl AsRef<Path>, arch: Architecture) -> Self;
+    fn new(esp: impl AsRef<Path>, boot: impl AsRef<Path>, arch: Architecture) -> Self;
 
     /// Return the used file paths to store as garbage collection roots.
     fn iter(&self) -> std::array::IntoIter<&PathBuf, N>;

--- a/rust/tool/shared/src/pe.rs
+++ b/rust/tool/shared/src/pe.rs
@@ -34,7 +34,7 @@ impl StubParameters {
         initrd_path: &Path,
         kernel_target: &Path,
         initrd_target: &Path,
-        esp: &Path,
+        boot: &Path,
     ) -> Result<Self> {
         // Resolve maximally those paths
         // We won't verify they are store paths, otherwise the mocking strategy will fail for our
@@ -44,8 +44,8 @@ impl StubParameters {
             lanzaboote_store_path: lanzaboote_stub.to_path_buf(),
             kernel_store_path: kernel_path.to_path_buf(),
             initrd_store_path: initrd_path.to_path_buf(),
-            kernel_path_at_esp: esp_relative_uefi_path(esp, kernel_target)?,
-            initrd_path_at_esp: esp_relative_uefi_path(esp, initrd_target)?,
+            kernel_path_at_esp: esp_relative_uefi_path(boot, kernel_target)?,
+            initrd_path_at_esp: esp_relative_uefi_path(boot, initrd_target)?,
             kernel_cmdline: Vec::new(),
             os_release_contents: Vec::new(),
         })

--- a/rust/tool/systemd/src/cli.rs
+++ b/rust/tool/systemd/src/cli.rs
@@ -120,6 +120,7 @@ fn install(args: InstallCommand) -> Result<()> {
         args.bootcounting_initial_tries,
         args.pcrlock_directory,
         args.esp,
+        args.boot,
         args.generations,
     );
 

--- a/rust/tool/systemd/src/cli.rs
+++ b/rust/tool/systemd/src/cli.rs
@@ -71,6 +71,10 @@ struct InstallCommand {
     /// EFI system partition mountpoint (e.g. efiSysMountPoint)
     esp: PathBuf,
 
+    /// $BOOT as per [Boot Loader Specification](https://uapi-group.org/specifications/specs/boot_loader_specification/#the-boot-partition-placeholder)
+    /// (i.e. xbootldrMountPoint if exists, otherwise efiSysMountPoint)
+    boot: PathBuf,
+
     /// List of generation links (e.g. /nix/var/nix/profiles/system-*-link)
     generations: Vec<PathBuf>,
 }

--- a/rust/tool/systemd/src/esp.rs
+++ b/rust/tool/systemd/src/esp.rs
@@ -9,6 +9,8 @@ use lanzaboote_tool::esp::EspPaths;
 pub struct SystemdEspPaths {
     pub esp: PathBuf,
     pub efi: PathBuf,
+    pub boot: PathBuf,
+    pub boot_efi: PathBuf,
     pub nixos: PathBuf,
     pub linux: PathBuf,
     pub efi_fallback_dir: PathBuf,
@@ -19,26 +21,30 @@ pub struct SystemdEspPaths {
     pub systemd_boot_loader_config: PathBuf,
 }
 
-impl EspPaths<10> for SystemdEspPaths {
-    fn new(esp: impl AsRef<Path>, architecture: Architecture) -> Self {
+impl EspPaths<12> for SystemdEspPaths {
+    fn new(esp: impl AsRef<Path>, boot: impl AsRef<Path>, architecture: Architecture) -> Self {
         let esp = esp.as_ref();
-        let efi = esp.join("EFI");
-        let efi_nixos = efi.join("nixos");
-        let efi_linux = efi.join("Linux");
-        let efi_systemd = efi.join("systemd");
-        let efi_efi_fallback_dir = efi.join("BOOT");
+        let boot = boot.as_ref();
+        let esp_efi = esp.join("EFI");
+        let boot_efi = boot.join("EFI");
+        let boot_efi_nixos = boot_efi.join("nixos");
+        let boot_efi_linux = boot_efi.join("Linux");
+        let esp_efi_systemd = esp_efi.join("systemd");
+        let esp_efi_efi_fallback_dir = esp_efi.join("BOOT");
         let loader = esp.join("loader");
         let systemd_boot_loader_config = loader.join("loader.conf");
 
         Self {
             esp: esp.to_path_buf(),
-            efi,
-            nixos: efi_nixos,
-            linux: efi_linux,
-            efi_fallback_dir: efi_efi_fallback_dir.clone(),
-            efi_fallback: efi_efi_fallback_dir.join(architecture.efi_fallback_filename()),
-            systemd: efi_systemd.clone(),
-            systemd_boot: efi_systemd.join(architecture.systemd_filename()),
+            efi: esp_efi,
+            boot: boot.to_path_buf(),
+            boot_efi,
+            nixos: boot_efi_nixos,
+            linux: boot_efi_linux,
+            efi_fallback_dir: esp_efi_efi_fallback_dir.clone(),
+            efi_fallback: esp_efi_efi_fallback_dir.join(architecture.efi_fallback_filename()),
+            systemd: esp_efi_systemd.clone(),
+            systemd_boot: esp_efi_systemd.join(architecture.systemd_filename()),
             loader,
             systemd_boot_loader_config,
         }
@@ -52,10 +58,12 @@ impl EspPaths<10> for SystemdEspPaths {
         &self.linux
     }
 
-    fn iter(&self) -> std::array::IntoIter<&PathBuf, 10> {
+    fn iter(&self) -> std::array::IntoIter<&PathBuf, 12> {
         [
             &self.esp,
             &self.efi,
+            &self.boot,
+            &self.boot_efi,
             &self.nixos,
             &self.linux,
             &self.efi_fallback_dir,

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -305,7 +305,7 @@ impl<S: Signer> Installer<S> {
             &initrd_location,
             &kernel_target,
             &initrd_target,
-            &self.esp_paths.esp,
+            &self.esp_paths.boot,
         )?
         .with_cmdline(&kernel_cmdline)
         .with_os_release_contents(os_release_contents.as_bytes());
@@ -398,11 +398,11 @@ impl<S: Signer> Installer<S> {
         let stub = fs::read(&stub_target)
             .with_context(|| format!("Failed to read the stub: {}", stub_target.display()))?;
         let kernel_path = resolve_efi_path(
-            &self.esp_paths.esp,
+            &self.esp_paths.boot,
             pe::read_section_data(&stub, ".linux").context("Missing kernel path.")?,
         )?;
         let initrd_path = resolve_efi_path(
-            &self.esp_paths.esp,
+            &self.esp_paths.boot,
             pe::read_section_data(&stub, ".initrd").context("Missing initrd path.")?,
         )?;
 

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -34,6 +34,7 @@ pub struct InstallerBuilder {
     bootcounting_initial_tries: u32,
     pcrlock_directory: Option<PathBuf>,
     esp: PathBuf,
+    boot: PathBuf,
     generation_links: Vec<PathBuf>,
 }
 
@@ -48,6 +49,7 @@ impl InstallerBuilder {
         bootcounting_initial_tries: u32,
         pcrlock_directory: Option<PathBuf>,
         esp: PathBuf,
+        boot: PathBuf,
         generation_links: Vec<PathBuf>,
     ) -> Self {
         Self {
@@ -59,6 +61,7 @@ impl InstallerBuilder {
             bootcounting_initial_tries,
             pcrlock_directory,
             esp,
+            boot,
             generation_links,
         }
     }

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -68,7 +68,7 @@ impl InstallerBuilder {
 
     pub fn build<S: Signer>(self, signer: S) -> Installer<S> {
         let mut gc_roots = Roots::new();
-        let esp_paths = SystemdEspPaths::new(self.esp, self.arch);
+        let esp_paths = SystemdEspPaths::new(self.esp, self.boot, self.arch);
         gc_roots.extend(esp_paths.iter());
 
         let pcrlock_paths = self.pcrlock_directory.map(PcrlockPaths::new);
@@ -413,7 +413,7 @@ impl<S: Signer> Installer<S> {
         Ok((stub_target, kernel_path, initrd_path))
     }
 
-    /// Install a content-addressed file to the `EFI/nixos` directory on the ESP.
+    /// Install a content-addressed file to the `EFI/nixos` directory on the $BOOT (ESP, or XBOOTLDR if exists).
     ///
     /// It is automatically added to the garbage collector roots.
     /// The full path to the target file is returned.

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -221,8 +221,8 @@ impl<S: Signer> Installer<S> {
         // Sync files to persistent storage. This may improve the
         // chance of a consistent boot directory in case the system
         // crashes.
-        let boot = File::open(&self.esp_paths.esp).context("Failed to open ESP root directory.")?;
-        syncfs(boot).context("Failed to sync ESP filesystem.")?;
+        let boot = File::open(&self.esp_paths.boot).context(format!("Failed to open $BOOT root directory ({}).", &self.esp_paths.boot.display()))?;
+        syncfs(boot).context(format!("Failed to sync $BOOT ({}) filesystem.", &self.esp_paths.boot.display()))?;
 
         Ok(())
     }

--- a/rust/tool/systemd/tests/integration/common.rs
+++ b/rust/tool/systemd/tests/integration/common.rs
@@ -166,6 +166,7 @@ fn random_string(length: usize) -> String {
 pub fn lanzaboote_install(
     config_limit: u64,
     esp_mountpoint: &Path,
+    boot_mountpoint: &Path,
     generation_links: impl IntoIterator<Item = impl AsRef<OsStr>>,
 ) -> Result<Output> {
     // To simplify the test setup, we use the systemd stub here instead of the lanzaboote stub. See
@@ -200,6 +201,7 @@ pub fn lanzaboote_install(
         .arg("--configuration-limit")
         .arg(config_limit.to_string())
         .arg(esp_mountpoint)
+        .arg(boot_mountpoint)
         .args(generation_links)
         .output()?;
 

--- a/rust/tool/systemd/tests/integration/gc.rs
+++ b/rust/tool/systemd/tests/integration/gc.rs
@@ -9,6 +9,7 @@ use crate::common::{self, count_files};
 #[test]
 fn keep_only_configured_number_of_generations() -> Result<()> {
     let esp_mountpoint = tempdir()?;
+    let boot_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let generation_links: Vec<PathBuf> = [1, 2, 3]
@@ -18,11 +19,17 @@ fn keep_only_configured_number_of_generations() -> Result<()> {
                 .expect("Failed to setup generation link")
         })
         .collect();
-    let stub_count = || count_files(&esp_mountpoint.path().join("EFI/Linux")).unwrap();
-    let kernel_and_initrd_count = || count_files(&esp_mountpoint.path().join("EFI/nixos")).unwrap();
+    let stub_count = || count_files(&boot_mountpoint.path().join("EFI/Linux")).unwrap();
+    let kernel_and_initrd_count =
+        || count_files(&boot_mountpoint.path().join("EFI/nixos")).unwrap();
 
     // Install all 3 generations.
-    let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), generation_links.clone())?;
+    let output0 = common::lanzaboote_install(
+        0,
+        esp_mountpoint.path(),
+        boot_mountpoint.path(),
+        generation_links.clone(),
+    )?;
     assert!(output0.status.success());
     assert_eq!(stub_count(), 6, "Wrong number of stubs after installation");
     assert_eq!(
@@ -33,7 +40,12 @@ fn keep_only_configured_number_of_generations() -> Result<()> {
 
     // Call `lanzatool install` again with a config limit of 2 and assert that one is deleted.
     // In addition, the garbage kernel should be deleted as well.
-    let output1 = common::lanzaboote_install(2, esp_mountpoint.path(), generation_links)?;
+    let output1 = common::lanzaboote_install(
+        2,
+        esp_mountpoint.path(),
+        boot_mountpoint.path(),
+        generation_links,
+    )?;
     assert!(output1.status.success());
     assert_eq!(stub_count(), 4, "Wrong number of stubs after gc.");
     assert_eq!(
@@ -48,6 +60,7 @@ fn keep_only_configured_number_of_generations() -> Result<()> {
 #[test]
 fn delete_garbage_kernel() -> Result<()> {
     let esp_mountpoint = tempdir()?;
+    let boot_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let generation_links: Vec<PathBuf> = [1, 2, 3]
@@ -57,22 +70,33 @@ fn delete_garbage_kernel() -> Result<()> {
                 .expect("Failed to setup generation link")
         })
         .collect();
-    let stub_count = || count_files(&esp_mountpoint.path().join("EFI/Linux")).unwrap();
-    let kernel_and_initrd_count = || count_files(&esp_mountpoint.path().join("EFI/nixos")).unwrap();
+    let stub_count = || count_files(&boot_mountpoint.path().join("EFI/Linux")).unwrap();
+    let kernel_and_initrd_count =
+        || count_files(&boot_mountpoint.path().join("EFI/nixos")).unwrap();
 
     // Install all 3 generations.
-    let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), generation_links.clone())?;
+    let output0 = common::lanzaboote_install(
+        0,
+        esp_mountpoint.path(),
+        boot_mountpoint.path(),
+        generation_links.clone(),
+    )?;
     assert!(output0.status.success());
 
     // Create a garbage kernel, which should be deleted.
     fs::write(
-        esp_mountpoint.path().join("EFI/nixos/kernel-garbage.efi"),
+        boot_mountpoint.path().join("EFI/nixos/kernel-garbage.efi"),
         "garbage",
     )?;
 
     // Call `lanzatool install` again with a config limit of 2.
     // In addition, the garbage kernel should be deleted as well.
-    let output1 = common::lanzaboote_install(2, esp_mountpoint.path(), generation_links)?;
+    let output1 = common::lanzaboote_install(
+        2,
+        esp_mountpoint.path(),
+        boot_mountpoint.path(),
+        generation_links,
+    )?;
     assert!(output1.status.success());
 
     assert_eq!(stub_count(), 4, "Wrong number of stubs after gc.");
@@ -88,6 +112,7 @@ fn delete_garbage_kernel() -> Result<()> {
 #[test]
 fn keep_unrelated_files_on_esp() -> Result<()> {
     let esp_mountpoint = tempdir()?;
+    let boot_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let generation_links: Vec<PathBuf> = [1, 2, 3]
@@ -99,11 +124,16 @@ fn keep_unrelated_files_on_esp() -> Result<()> {
         .collect();
 
     // Install all 3 generations.
-    let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), generation_links.clone())?;
+    let output0 = common::lanzaboote_install(
+        0,
+        esp_mountpoint.path(),
+        boot_mountpoint.path(),
+        generation_links.clone(),
+    )?;
     assert!(output0.status.success());
 
     let unrelated_loader_config = esp_mountpoint.path().join("loader/loader.conf");
-    let unrelated_uki = esp_mountpoint.path().join("EFI/Linux/ubuntu.efi");
+    let unrelated_uki = boot_mountpoint.path().join("EFI/Linux/ubuntu.efi");
     let unrelated_os = esp_mountpoint.path().join("EFI/windows");
     let unrelated_firmware = esp_mountpoint.path().join("dell");
     fs::File::create(&unrelated_loader_config)?;
@@ -112,7 +142,12 @@ fn keep_unrelated_files_on_esp() -> Result<()> {
     fs::create_dir(&unrelated_firmware)?;
 
     // Call `lanzatool install` again with a config limit of 2.
-    let output1 = common::lanzaboote_install(2, esp_mountpoint.path(), generation_links)?;
+    let output1 = common::lanzaboote_install(
+        2,
+        esp_mountpoint.path(),
+        boot_mountpoint.path(),
+        generation_links,
+    )?;
     assert!(output1.status.success());
 
     assert!(unrelated_loader_config.exists());

--- a/rust/tool/systemd/tests/integration/install.rs
+++ b/rust/tool/systemd/tests/integration/install.rs
@@ -12,6 +12,7 @@ use crate::common::{
 #[test]
 fn do_not_install_duplicates() -> Result<()> {
     let esp = tempdir()?;
+    let boot = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let toplevel = common::setup_toplevel(tmpdir.path())?;
@@ -20,10 +21,12 @@ fn do_not_install_duplicates() -> Result<()> {
     let generation_link2 = setup_generation_link_from_toplevel(&toplevel, profiles.path(), 2)?;
     let generation_links = vec![generation_link1, generation_link2];
 
-    let stub_count = || count_files(&esp.path().join("EFI/Linux")).unwrap();
-    let kernel_and_initrd_count = || count_files(&esp.path().join("EFI/nixos")).unwrap();
+    let stub_count = || count_files(&boot.path().join("EFI/Linux")).unwrap();
+    let kernel_and_initrd_count =
+        || count_files(&boot.path().join("EFI/nixos")).unwrap();
 
-    let output1 = common::lanzaboote_install(0, esp.path(), generation_links)?;
+    let output1 =
+        common::lanzaboote_install(0, esp.path(), boot.path(), generation_links)?;
     assert!(output1.status.success());
     assert_eq!(stub_count(), 4, "Wrong number of stubs after installation");
     assert_eq!(
@@ -37,18 +40,24 @@ fn do_not_install_duplicates() -> Result<()> {
 #[test]
 fn do_not_overwrite_images() -> Result<()> {
     let esp = tempdir()?;
+    let boot = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let toplevel = common::setup_toplevel(tmpdir.path())?;
 
-    let image1 = common::image_path(&esp, 1, &toplevel)?;
-    let image2 = common::image_path(&esp, 2, &toplevel)?;
+    let image1 = common::image_path(&boot, 1, &toplevel)?;
+    let image2 = common::image_path(&boot, 2, &toplevel)?;
 
     let generation_link1 = setup_generation_link_from_toplevel(&toplevel, profiles.path(), 1)?;
     let generation_link2 = setup_generation_link_from_toplevel(&toplevel, profiles.path(), 2)?;
     let generation_links = vec![generation_link1, generation_link2];
 
-    let output1 = common::lanzaboote_install(0, esp.path(), generation_links.clone())?;
+    let output1 = common::lanzaboote_install(
+        0,
+        esp.path(),
+        boot.path(),
+        generation_links.clone(),
+    )?;
     assert!(output1.status.success());
 
     assert!(verify_signature(&image1)?);
@@ -56,7 +65,8 @@ fn do_not_overwrite_images() -> Result<()> {
     assert!(!verify_signature(&image1)?);
     assert!(verify_signature(&image2)?);
 
-    let output2 = common::lanzaboote_install(0, esp.path(), generation_links)?;
+    let output2 =
+        common::lanzaboote_install(0, esp.path(), boot.path(), generation_links)?;
     assert!(output2.status.success());
 
     assert!(!verify_signature(&image1)?);
@@ -68,24 +78,35 @@ fn do_not_overwrite_images() -> Result<()> {
 #[test]
 fn detect_generation_number_reuse() -> Result<()> {
     let esp = tempdir()?;
+    let boot = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let toplevel1 = common::setup_toplevel(tmpdir.path())?;
     let toplevel2 = common::setup_toplevel(tmpdir.path())?;
 
-    let image1 = common::image_path(&esp, 1, &toplevel1)?;
+    let image1 = common::image_path(&boot, 1, &toplevel1)?;
     // this deliberately gets the same number!
-    let image2 = common::image_path(&esp, 1, &toplevel2)?;
+    let image2 = common::image_path(&boot, 1, &toplevel2)?;
 
     let generation_link1 = setup_generation_link_from_toplevel(&toplevel1, profiles.path(), 1)?;
-    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link1])?;
+    let output1 = common::lanzaboote_install(
+        0,
+        esp.path(),
+        boot.path(),
+        vec![generation_link1],
+    )?;
     assert!(output1.status.success());
     assert!(image1.exists());
     assert!(!image2.exists());
 
     std::fs::remove_dir_all(profiles.path().join("system-1-link"))?;
     let generation_link2 = setup_generation_link_from_toplevel(&toplevel2, profiles.path(), 1)?;
-    let output2 = common::lanzaboote_install(0, esp.path(), vec![generation_link2])?;
+    let output2 = common::lanzaboote_install(
+        0,
+        esp.path(),
+        boot.path(),
+        vec![generation_link2],
+    )?;
     assert!(output2.status.success());
     assert!(!image1.exists());
     assert!(image2.exists());
@@ -96,6 +117,7 @@ fn detect_generation_number_reuse() -> Result<()> {
 #[test]
 fn content_addressing_works() -> Result<()> {
     let esp = tempdir()?;
+    let boot = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let toplevel = common::setup_toplevel(tmpdir.path())?;
@@ -106,10 +128,11 @@ fn content_addressing_works() -> Result<()> {
     let kernel_hash_source =
         hash_file(&toplevel.join("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-6.1.1/kernel"));
 
-    let output0 = common::lanzaboote_install(1, esp.path(), generation_links)?;
+    let output0 =
+        common::lanzaboote_install(1, esp.path(), boot.path(), generation_links)?;
     assert!(output0.status.success());
 
-    let kernel_path = esp.path().join(format!(
+    let kernel_path = boot.path().join(format!(
         "EFI/nixos/kernel-6.1.1-{}.efi",
         Base32Unpadded::encode_string(&kernel_hash_source)
     ));

--- a/rust/tool/systemd/tests/integration/os_release.rs
+++ b/rust/tool/systemd/tests/integration/os_release.rs
@@ -9,6 +9,7 @@ use crate::common;
 #[test]
 fn generate_expected_os_release() -> Result<()> {
     let esp_mountpoint = tempdir()?;
+    let boot_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let toplevel = common::setup_toplevel(tmpdir.path())?;
@@ -17,10 +18,15 @@ fn generate_expected_os_release() -> Result<()> {
         common::setup_generation_link_from_toplevel(&toplevel, profiles.path(), 1)
             .expect("Failed to setup generation link");
 
-    let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), vec![generation_link])?;
+    let output0 = common::lanzaboote_install(
+        0,
+        esp_mountpoint.path(),
+        boot_mountpoint.path(),
+        vec![generation_link],
+    )?;
     assert!(output0.status.success());
 
-    let stub_data = fs::read(common::image_path(&esp_mountpoint, 1, &toplevel)?)?;
+    let stub_data = fs::read(common::image_path(&boot_mountpoint, 1, &toplevel)?)?;
     let os_release_section = pe_section(&stub_data, ".osrel")
         .context("Failed to read .osrelease PE section.")?
         .to_owned();

--- a/rust/tool/systemd/tests/integration/systemd_boot.rs
+++ b/rust/tool/systemd/tests/integration/systemd_boot.rs
@@ -11,6 +11,7 @@ use crate::common::{self, SYSTEM, hash_file, mtime, remove_signature, verify_sig
 #[test]
 fn keep_systemd_boot_binaries() -> Result<()> {
     let esp = tempdir()?;
+    let boot_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
@@ -19,7 +20,12 @@ fn keep_systemd_boot_binaries() -> Result<()> {
     let systemd_boot_path = systemd_boot_path(&esp);
     let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
 
-    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+    let output0 = common::lanzaboote_install(
+        0,
+        esp.path(),
+        boot_mountpoint.path(),
+        vec![&generation_link],
+    )?;
     assert!(output0.status.success());
 
     // Use the modification time instead of a hash because the hash would be the same even if the
@@ -27,7 +33,8 @@ fn keep_systemd_boot_binaries() -> Result<()> {
     let systemd_boot_mtime0 = mtime(&systemd_boot_path);
     let systemd_boot_fallback_mtime0 = mtime(&systemd_boot_fallback_path);
 
-    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+    let output1 =
+        common::lanzaboote_install(0, esp.path(), boot_mountpoint.path(), vec![generation_link])?;
     assert!(output1.status.success());
 
     let systemd_boot_mtime1 = mtime(&systemd_boot_path);
@@ -48,6 +55,7 @@ fn keep_systemd_boot_binaries() -> Result<()> {
 #[test]
 fn overwrite_malformed_systemd_boot_binaries() -> Result<()> {
     let esp = tempdir()?;
+    let boot_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
@@ -56,7 +64,12 @@ fn overwrite_malformed_systemd_boot_binaries() -> Result<()> {
     let systemd_boot_path = systemd_boot_path(&esp);
     let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
 
-    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+    let output0 = common::lanzaboote_install(
+        0,
+        esp.path(),
+        boot_mountpoint.path(),
+        vec![&generation_link],
+    )?;
     assert!(output0.status.success());
 
     // Make systemd-boot binaries malformed by truncating them.
@@ -66,7 +79,8 @@ fn overwrite_malformed_systemd_boot_binaries() -> Result<()> {
     let malformed_systemd_boot_hash = hash_file(&systemd_boot_path);
     let malformed_systemd_boot_fallback_hash = hash_file(&systemd_boot_fallback_path);
 
-    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+    let output1 =
+        common::lanzaboote_install(0, esp.path(), boot_mountpoint.path(), vec![generation_link])?;
     assert!(output1.status.success());
 
     let systemd_boot_hash = hash_file(&systemd_boot_path);
@@ -87,6 +101,7 @@ fn overwrite_malformed_systemd_boot_binaries() -> Result<()> {
 #[test]
 fn overwrite_unsigned_systemd_boot_binaries() -> Result<()> {
     let esp = tempdir()?;
+    let boot_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
     let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
@@ -95,7 +110,12 @@ fn overwrite_unsigned_systemd_boot_binaries() -> Result<()> {
     let systemd_boot_path = systemd_boot_path(&esp);
     let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
 
-    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+    let output0 = common::lanzaboote_install(
+        0,
+        esp.path(),
+        boot_mountpoint.path(),
+        vec![&generation_link],
+    )?;
     assert!(output0.status.success());
 
     remove_signature(&systemd_boot_path)?;
@@ -103,7 +123,8 @@ fn overwrite_unsigned_systemd_boot_binaries() -> Result<()> {
     assert!(!verify_signature(&systemd_boot_path)?);
     assert!(!verify_signature(&systemd_boot_fallback_path)?);
 
-    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+    let output1 =
+        common::lanzaboote_install(0, esp.path(), boot_mountpoint.path(), vec![generation_link])?;
     assert!(output1.status.success());
 
     assert!(verify_signature(&systemd_boot_path)?);


### PR DESCRIPTION
Fixes #173

In some systems, especially those pre-installed with Windows, the EFI System Partition (ESP) might not be large enough to contain the kernels and initrds used to boot.

`XBOOTLDR` is a partition specified by [Boot Loader Specification](https://uapi-group.org/specifications/specs/boot_loader_specification/#the-partitions) to accommodate storing additional boot entries.

Currently, Lanzaboote only supports writing kernels, initrds, and EFI stubs to ESP but not `XBOOTLDR`. This PR adds support for it by

- Add an extra argument to `lzbt-systemd` to denote `$BOOT` partition, which is a placeholder for `XBOOTLDR` or ESP, if `XBOOTLDR` doesn't exists.
- Retrieve `XBOOTLDR` mount point from `boot.loader.systemd-boot.xbootldrMountPoint` and pass it along to `lzbt-systemd` accordingly.

[This workaround](https://github.com/nix-community/lanzaboote/issues/173#issuecomment-1532386210) mentioned in #173 makes the update image for `fwupd` does not work, since `fwupd` writes the update bundle to `ESP/EFI/nixos`, which is bind to `XBOOTLDR` in the workaround, and thus, the bundle isn't recognised by the UEFI firmware on boot.