### PR TITLE
 feat: add boot-counting support to lanzaboote

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -141,6 +141,18 @@ in
       '';
     };
 
+    bootCounting = {
+      initialTries = lib.mkOption {
+        type = lib.types.ints.u32;
+        default = 0;
+        description = ''
+          The number of boot counting tries to set for new boot entries.
+          Setting this to zero, disables boot counting.
+          See https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/
+        '';
+      };
+    };
+
     installCommand = lib.mkOption {
       type = lib.types.str;
       readOnly = true;
@@ -157,14 +169,16 @@ in
           --systemd ${config.systemd.package} \
           --systemd-boot-loader-config ${loaderConfigFile} \
           --configuration-limit ${toString configurationLimit} \
-          --allow-unsigned ${lib.boolToString cfg.allowUnsigned}'';
+          --allow-unsigned ${lib.boolToString cfg.allowUnsigned} \
+          --bootcounting-initial-tries ${toString cfg.bootCounting.initialTries}'';
       defaultText = lib.literalExpression ''
         ''${lib.getExe config.boot.lanzaboote.package} install \
           --system ''${config.boot.kernelPackages.stdenv.hostPlatform.system} \
           --systemd ''${config.systemd.package} \
           --systemd-boot-loader-config ''${loaderConfigFile} \
           --configuration-limit ''${toString configurationLimit} \
-          --allow-unsigned ''${lib.boolToString config.boot.lanzaboote.allowUnsigned}'';
+          --allow-unsigned ''${lib.boolToString config.boot.lanzaboote.allowUnsigned} \
+          --bootcounting-initial-tries ''${toString config.boot.lanzaboote.bootCounting.initialTries}'';
     };
 
     extraEfiSysMountPoints = lib.mkOption {

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -26,6 +26,7 @@ in
   export-efivars-tpm = runTest ./lanzaboote/export-efivars-tpm.nix;
   extra-efi-partitions = runTest ./lanzaboote/extra-efi-partitions.nix;
   auto-generate-enroll = runTest ./lanzaboote/auto-generate-enroll.nix;
+  boot-counting = runTest ./lanzaboote/boot-counting.nix;
 
   systemd-pcrlock = runTest ./lanzaboote/systemd-pcrlock.nix;
   systemd-measured-uki = runTest ./lanzaboote/systemd-measured-uki.nix;

--- a/nix/tests/lanzaboote/boot-counting.nix
+++ b/nix/tests/lanzaboote/boot-counting.nix
@@ -1,0 +1,130 @@
+let
+  sortKey = "mySpecialSortKey";
+  sortKeySpectator = "spectatorSortKey";
+  sortKeyBad = "allthewayontop";
+in
+{
+  name = "lanzaboote boot counting";
+
+  nodes = {
+    machine = {
+      imports = [ ./common/lanzaboote.nix ];
+
+      boot.lanzaboote = {
+        inherit sortKey;
+        bootCounting.initialTries = 2;
+      };
+
+      # Boot is successful if multi-user is reached
+      systemd.targets.boot-complete.after = [ "multi-user.target" ];
+
+      specialisation = {
+        # This specialisation is ordered first, but it will fail to boot successfully
+        bad.configuration =
+          { lib, ... }:
+          {
+            boot.lanzaboote.sortKey = lib.mkForce sortKeyBad;
+
+            systemd.services."failing" = {
+              script = "exit 1";
+              requiredBy = [ "boot-complete.target" ];
+              before = [ "boot-complete.target" ];
+              serviceConfig.Type = "oneshot";
+            };
+          };
+
+        # This specialisation should be ordered at the bottom, and we should never boot it
+        spectator.configuration =
+          { lib, ... }:
+          {
+            boot.lanzaboote.sortKey = lib.mkForce sortKeySpectator;
+          };
+        # Specialisation with boot counting turned off, this should not matter
+        spectator2.configuration =
+          { lib, ... }:
+          {
+            boot.lanzaboote = {
+              sortKey = lib.mkForce sortKeySpectator;
+              bootCounting.initialTries = lib.mkForce 0;
+            };
+          };
+      };
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      orig = nodes.machine.system.build.toplevel;
+      bad = nodes.machine.specialisation.bad.configuration.system.build.toplevel;
+    in
+    (import ./common/image-helper.nix { inherit (nodes) machine; })
+    +
+      # python
+      ''
+        orig = "${orig}"
+        bad = "${bad}"
+
+        def check_current_system(system_path:str):
+          current_sys = machine.succeed('readlink -f /run/current-system').strip()
+          print(f'current system: {current_sys}')
+          machine.succeed(f'test "{current_sys}" = "{system_path}"')
+
+        def check_boot_entry(
+          generation_counter:int,
+          specialisation:str|None,
+          boot_counter:int=0,
+          bad_counter:int=0
+        ):
+          regex = rf"^/boot/EFI/Linux/nixos-generation-{generation_counter}"
+
+          if specialisation:
+            regex += f"-specialisation-{specialisation}"
+
+          regex += r"-[0-9a-z]{52}"
+
+          if boot_counter != 0 or bad_counter != 0:
+            regex += rf"\+{boot_counter}"
+            if bad_counter != 0:
+              regex += rf"-{bad_counter}"
+
+          regex += r"\.efi$"
+
+          find_command = rf"find /boot/EFI/Linux/ -regextype posix-extended -regex '{regex}' -type f | grep -q '.'"
+
+          machine.succeed(find_command)
+
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+        # Ensure we booted using an entry with counters enabled
+        machine.succeed(
+          "test -e /sys/firmware/efi/efivars/LoaderBootCountPath-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+        )
+        print(machine.succeed("bootctl list"))
+        check_current_system(bad)
+        check_boot_entry(generation_counter=1, specialisation=None, boot_counter=2)
+        check_boot_entry(generation_counter=1, specialisation="spectator", boot_counter=2)
+        check_boot_entry(generation_counter=1, specialisation="bad", boot_counter=1, bad_counter=1)
+        machine.shutdown()
+
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+        print(machine.succeed("bootctl list"))
+        check_current_system(bad)
+        check_boot_entry(generation_counter=1, specialisation=None, boot_counter=2)
+        check_boot_entry(generation_counter=1, specialisation="spectator", boot_counter=2)
+        check_boot_entry(generation_counter=1, specialisation="bad", boot_counter=0, bad_counter=2)
+        machine.shutdown()
+
+        # Should boot back into original configuration
+        machine.start()
+        check_current_system(orig)
+        machine.wait_for_unit("multi-user.target")
+        machine.wait_for_unit("systemd-bless-boot.service")
+        print(machine.succeed("bootctl list"))
+        check_boot_entry(generation_counter=1, specialisation=None)
+        check_boot_entry(generation_counter=1, specialisation="spectator", boot_counter=2)
+        check_boot_entry(generation_counter=1, specialisation="bad", boot_counter=0, bad_counter=2)
+        machine.shutdown()
+      '';
+}

--- a/rust/tool/Cargo.lock
+++ b/rust/tool/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +499,7 @@ dependencies = [
  "log",
  "nix",
  "rand",
+ "regex",
  "serde_json",
  "sha2",
  "stderrlog",
@@ -653,10 +663,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustix"

--- a/rust/tool/systemd/Cargo.toml
+++ b/rust/tool/systemd/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.145"
 sha2 = "0.10.9"
 tempfile = "3.23.0"
 nix = { version = "0.31.0", default-features = false, features = [ "fs" ] }
+regex = "1.12.2"
 
 [dev-dependencies]
 assert_cmd = "2.1.1"

--- a/rust/tool/systemd/src/cli.rs
+++ b/rust/tool/systemd/src/cli.rs
@@ -61,6 +61,10 @@ struct InstallCommand {
     #[arg(long, default_value_t = 1)]
     configuration_limit: usize,
 
+    /// Initial number of boot counting tries, set to zero to disable boot counting
+    #[arg(long, default_value_t = 0)]
+    bootcounting_initial_tries: u32,
+
     /// EFI system partition mountpoint (e.g. efiSysMountPoint)
     esp: PathBuf,
 
@@ -106,6 +110,7 @@ fn install(args: InstallCommand) -> Result<()> {
         args.systemd,
         args.systemd_boot_loader_config,
         args.configuration_limit,
+        args.bootcounting_initial_tries,
         args.esp,
         args.generations,
     );

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -8,6 +8,7 @@ use std::string::ToString;
 use anyhow::{Context, Result, anyhow};
 use base32ct::{Base32Unpadded, Encoding};
 use nix::unistd::syncfs;
+use regex::Regex;
 use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
@@ -29,17 +30,20 @@ pub struct InstallerBuilder {
     systemd: PathBuf,
     systemd_boot_loader_config: PathBuf,
     configuration_limit: usize,
+    bootcounting_initial_tries: u32,
     esp: PathBuf,
     generation_links: Vec<PathBuf>,
 }
 
 impl InstallerBuilder {
+    #![allow(clippy::too_many_arguments)]
     pub fn new(
         lanzaboote_stub: impl AsRef<Path>,
         arch: Architecture,
         systemd: PathBuf,
         systemd_boot_loader_config: PathBuf,
         configuration_limit: usize,
+        bootcounting_initial_tries: u32,
         esp: PathBuf,
         generation_links: Vec<PathBuf>,
     ) -> Self {
@@ -49,6 +53,7 @@ impl InstallerBuilder {
             systemd,
             systemd_boot_loader_config,
             configuration_limit,
+            bootcounting_initial_tries,
             esp,
             generation_links,
         }
@@ -67,6 +72,7 @@ impl InstallerBuilder {
             systemd_boot_loader_config: self.systemd_boot_loader_config,
             signer,
             configuration_limit: self.configuration_limit,
+            bootcounting_initial_tries: self.bootcounting_initial_tries,
             esp_paths,
             generation_links: self.generation_links,
             arch: self.arch,
@@ -82,6 +88,7 @@ pub struct Installer<S: Signer> {
     systemd_boot_loader_config: PathBuf,
     signer: S,
     configuration_limit: usize,
+    bootcounting_initial_tries: u32,
     esp_paths: SystemdEspPaths,
     generation_links: Vec<PathBuf>,
     arch: Architecture,
@@ -207,7 +214,7 @@ impl<S: Signer> Installer<S> {
     /// All installed files are added as garbage collector roots.
     fn install_generation(&mut self, generation: &Generation) -> Result<()> {
         // If the generation is already properly installed, don't overwrite it.
-        if self.register_installed_generation(generation).is_ok() {
+        if self.register_installed_generation(generation)? {
             return Ok(());
         }
 
@@ -284,10 +291,10 @@ impl<S: Signer> Installer<S> {
         let lanzaboote_image_path = lanzaboote_image(&tempdir, &parameters)
             .context("Failed to build and sign lanzaboote stub image.")?;
 
-        let stub_target = self
-            .esp_paths
-            .linux
-            .join(stub_name(generation, &self.signer).context("Get stub name")?);
+        let stub_target = self.esp_paths.linux.join(
+            stub_name(generation, &self.signer, self.bootcounting_initial_tries)
+                .context("Get stub name")?,
+        );
         self.gc_roots.extend([&stub_target]);
         install_signed(&self.signer, &lanzaboote_image_path, &stub_target)
             .context("Failed to install the Lanzaboote stub.")?;
@@ -297,12 +304,55 @@ impl<S: Signer> Installer<S> {
 
     /// Register the files of an already installed generation as garbage collection roots.
     ///
-    /// An error should not be considered fatal; the generation should be (re-)installed instead.
-    fn register_installed_generation(&mut self, generation: &Generation) -> Result<()> {
-        let stub_target = self
-            .esp_paths
-            .linux
-            .join(stub_name(generation, &self.signer).context("While getting stub name")?);
+    /// The bool indicates whether the generation was properly installed,
+    /// if this function returns Ok(false) the generation should be (re-)installed.
+    fn register_installed_generation(&mut self, generation: &Generation) -> Result<bool> {
+        // A boot loader entry file name may contain a plus (+) followed by a number.
+        // This may optionally be followed by a minus (-) followed by a second number.
+        // The dot (.) and file name suffix (conf or efi) must immediately follow.
+        // The first number is the amount of times the boot entry should (still) be tried.
+        // The second number is the amount of times the boot entry has been tried unsuccessfully.
+        // See https://uapi-group.org/specifications/specs/boot_loader_specification/#boot-counting
+        let pattern = format!(
+            r"{}(\+\d(-\d)?)?.efi",
+            stub_prefix(generation, &self.signer)?
+        );
+        let regex =
+            Regex::new(&pattern).context("Failed to construct regex to read stubs from ESP")?;
+
+        // An Err returned from this function means that we couldn't properly read
+        // the different files belonging to this generation, so it should be reinstalled
+        if let Ok((stub_target, kernel_path, initrd_path)) = self.read_installed_generation(regex) {
+            self.gc_roots
+                .extend([&stub_target, &kernel_path, &initrd_path]);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    // Read the stub, kernel and initrd paths belonging to the generation matching the given regex.
+    //
+    // The regex is used to find the generation based on the stub filename.
+    // The regex should only match a single generation on disk.
+    // An Err returned from this function means that we couldn't properly read
+    // the different files belonging to this generation, so it should be reinstalled
+    fn read_installed_generation(&mut self, regex: Regex) -> Result<(PathBuf, PathBuf, PathBuf)> {
+        // Read the esp dir and find the entry that corresponds to the generation.
+        // There should only be one such entry.
+        let stub_target = fs::read_dir(&self.esp_paths.linux)?
+            .filter_map(|maybe_entry| {
+                if let Ok(entry) = maybe_entry
+                    && let Ok(name) = entry.file_name().into_string()
+                    && regex.is_match(&name)
+                {
+                    return Some(entry.path());
+                }
+                None
+            })
+            .next()
+            .context("While determining stub name")?;
+
         let stub = fs::read(&stub_target)
             .with_context(|| format!("Failed to read the stub: {}", stub_target.display()))?;
         let kernel_path = resolve_efi_path(
@@ -314,13 +364,11 @@ impl<S: Signer> Installer<S> {
             pe::read_section_data(&stub, ".initrd").context("Missing initrd path.")?,
         )?;
 
-        if !kernel_path.exists() && !initrd_path.exists() {
+        if !kernel_path.exists() || !initrd_path.exists() {
             anyhow::bail!("Missing kernel or initrd.");
         }
-        self.gc_roots
-            .extend([&stub_target, &kernel_path, &initrd_path]);
 
-        Ok(())
+        Ok((stub_target, kernel_path, initrd_path))
     }
 
     /// Install a content-addressed file to the `EFI/nixos` directory on the ESP.
@@ -397,7 +445,21 @@ fn resolve_efi_path(esp: &Path, efi_path: &[u8]) -> Result<PathBuf> {
 /// Compute the file name to be used for the stub of a certain generation, signed with the given key.
 ///
 /// The generated name is input-addressed by the toplevel corresponding to the generation and the public part of the signing key.
-fn stub_name<S: Signer>(generation: &Generation, signer: &S) -> Result<PathBuf> {
+fn stub_name<S: Signer>(
+    generation: &Generation,
+    signer: &S,
+    bootcounting_tries: u32,
+) -> Result<PathBuf> {
+    stub_prefix(generation, signer).map(|prefix| {
+        PathBuf::from(if bootcounting_tries > 0 {
+            format!("{}+{}.efi", prefix, bootcounting_tries)
+        } else {
+            format!("{}.efi", prefix)
+        })
+    })
+}
+
+fn stub_prefix<S: Signer>(generation: &Generation, signer: &S) -> Result<String> {
     let bootspec = &generation.spec.bootspec.bootspec;
     let public_key = signer.get_public_key()?;
     let stub_inputs = [
@@ -412,15 +474,15 @@ fn stub_name<S: Signer>(generation: &Generation, signer: &S) -> Result<PathBuf> 
         serde_json::to_string(&stub_inputs).unwrap(),
     ));
     if let Some(specialisation_name) = &generation.specialisation_name {
-        Ok(PathBuf::from(format!(
-            "nixos-generation-{}-specialisation-{}-{}.efi",
+        Ok(format!(
+            "nixos-generation-{}-specialisation-{}-{}",
             generation, specialisation_name, stub_input_hash
-        )))
+        ))
     } else {
-        Ok(PathBuf::from(format!(
-            "nixos-generation-{}-{}.efi",
+        Ok(format!(
+            "nixos-generation-{}-{}",
             generation, stub_input_hash
-        )))
+        ))
     }
 }
 


### PR DESCRIPTION
See https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/

Boot counting is controlled with a single option, `boot.lanzaboote.bootCounting.initialTries`, if this option is set to a non-zero value, new boot entries will be created with a counter added, set to the value specified in that option. If the option is set to zero, which is also the default, then no boot-counting counters will be added.
Already existing entries will not be modified, so boot counting only applies to new boot entries.

CC: @RaitoBezarius 