### PR TITLE
feat: allow specialisations to set their own sort keys

### DIFF
--- a/nix/tests/lanzaboote/common/image-helper.nix
+++ b/nix/tests/lanzaboote/common/image-helper.nix
@@ -22,6 +22,6 @@
   os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
 
   # Enroll keys via systemd-boot by rebooting
-  machine.start(allow_reboot=True)
-  machine.connected = False
+  ${machine.networking.hostName}.start(allow_reboot=True)
+  ${machine.networking.hostName}.connected = False
 ''

--- a/nix/tests/lanzaboote/specialisation.nix
+++ b/nix/tests/lanzaboote/specialisation.nix
@@ -1,32 +1,79 @@
+let
+  sortKey = "mySpecialSortKey";
+  sortKeySpecialisation = "variantSortKey";
+  # Sort key that should put this boot entry in the beginning
+  sortKeySpecialisation2 = "avariantSortKey";
+in
 {
   name = "lanzaboote-specialisation";
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
-      imports = [ ./common/lanzaboote.nix ];
+  nodes = {
+    machine =
+      { lib, pkgs, ... }:
+      {
+        imports = [ ./common/lanzaboote.nix ];
 
-      specialisation.variant.configuration = {
-        environment.systemPackages = [
-          pkgs.efibootmgr
-        ];
+        boot.lanzaboote = { inherit sortKey; };
+
+        specialisation.variant.configuration = {
+          boot.lanzaboote.sortKey = lib.mkForce sortKeySpecialisation;
+          environment.systemPackages = [
+            pkgs.efibootmgr
+          ];
+        };
       };
-    };
+
+    machine2 =
+      { lib, pkgs, ... }:
+      {
+        imports = [ ./common/lanzaboote.nix ];
+
+        boot.lanzaboote = { inherit sortKey; };
+
+        specialisation.variant.configuration = {
+          boot.lanzaboote.sortKey = lib.mkForce sortKeySpecialisation2;
+          environment.systemPackages = [
+            pkgs.efibootmgr
+          ];
+        };
+      };
+  };
 
   testScript =
     { nodes, ... }:
     (import ./common/image-helper.nix { inherit (nodes) machine; })
+    +
+      # python
+      ''
+        print(machine.succeed("ls -lah /boot/EFI/Linux"))
+
+        out = machine.succeed("bootctl status")
+        t.assertIn("sort-key: ${sortKey}", out, "did not find sort key for machine2")
+
+        # TODO: make it more reliable to find this filename, i.e. read it from somewhere?
+        machine.succeed("bootctl set-default nixos-generation-1-specialisation-variant-\\*.efi")
+        machine.succeed("sync")
+        machine.fail("efibootmgr")
+        machine.crash()
+        machine.start()
+        print(machine.succeed("bootctl"))
+
+        out = machine.succeed("bootctl status")
+        t.assertIn("sort-key: ${sortKeySpecialisation}", out, "did not find specialisation sort key for machine")
+
+        # Only the specialisation contains the efibootmgr binary.
+        machine.succeed("efibootmgr")
+
+        machine.crash()
+      ''
+
+    + (import ./common/image-helper.nix { machine = nodes.machine2; })
+
     + ''
-      machine.start()
-      print(machine.succeed("ls -lah /boot/EFI/Linux"))
-      # TODO: make it more reliable to find this filename, i.e. read it from somewhere?
-      machine.succeed("bootctl set-default nixos-generation-1-specialisation-variant-\*.efi")
-      machine.succeed("sync")
-      machine.fail("efibootmgr")
-      machine.crash()
-      machine.start()
-      print(machine.succeed("bootctl"))
-      # Only the specialisation contains the efibootmgr binary.
-      machine.succeed("efibootmgr")
+      # The second machine should have booted into the specialisation
+      out = machine2.succeed("bootctl status")
+      print(out)
+      t.assertIn("sort-key: ${sortKeySpecialisation2}", out, "did not find specialisation sort key for machine2")
+      machine2.succeed("efibootmgr")
     '';
 }

--- a/rust/tool/shared/src/generation.rs
+++ b/rust/tool/shared/src/generation.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
@@ -6,7 +7,6 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use bootspec::BootJson;
 use bootspec::BootSpec;
-use bootspec::Specialisation;
 use bootspec::SpecialisationName;
 use serde::Deserialize;
 use time::Date;
@@ -34,6 +34,24 @@ impl Default for LanzabooteExtension {
     }
 }
 
+impl From<bootspec::Specialisation> for LanzabooteExtension {
+    fn from(spec: bootspec::Specialisation) -> Self {
+        spec.extensions
+            .get("org.nix-community.lanzaboote")
+            .and_then(|v| serde_json::from_value::<LanzabooteExtension>(v.clone()).ok())
+            .unwrap_or_default()
+    }
+}
+
+impl From<bootspec::BootJson> for LanzabooteExtension {
+    fn from(spec: bootspec::BootJson) -> Self {
+        spec.extensions
+            .get("org.nix-community.lanzaboote")
+            .and_then(|v| serde_json::from_value::<LanzabooteExtension>(v.clone()).ok())
+            .unwrap_or_default()
+    }
+}
+
 /// A system configuration.
 ///
 /// Can be built from a GenerationLink.
@@ -52,6 +70,8 @@ pub struct Generation {
     pub specialisation_name: Option<SpecialisationName>,
     /// Top-level extended boot specification
     pub spec: ExtendedBootJson,
+    /// The set of specialisations of this generation
+    pub specialisations: HashMap<SpecialisationName, Generation>,
 }
 
 impl Generation {
@@ -63,33 +83,59 @@ impl Generation {
             .or_else(|_err| BootJson::synthesize_latest(&link.path)
                     .context("Failed to read a bootspec (missing bootspec?) and failed to synthesize a valid replacement bootspec."))?;
 
-        let bootspec: BootSpec = boot_json.generation.try_into()?;
-        let lanzaboote_extension = boot_json
-            .extensions
-            .get("org.nix-community.lanzaboote")
-            .and_then(|v| serde_json::from_value::<LanzabooteExtension>(v.clone()).ok())
-            .unwrap_or_default();
+        Self::parse_boot_json(link, None, boot_json)
+    }
+
+    fn parse_specialisation(
+        link: &GenerationLink,
+        specialisation_name: SpecialisationName,
+        specialisation: bootspec::Specialisation,
+    ) -> Result<Self> {
+        Ok(Self {
+            version: link.version,
+            build_time: link.build_time,
+            specialisation_name: Some(specialisation_name),
+            spec: ExtendedBootJson {
+                bootspec: specialisation.clone().generation,
+                lanzaboote_extension: specialisation.clone().into(),
+            },
+            specialisations: Self::parse_specialisations(
+                link,
+                specialisation.generation.specialisations,
+            )?,
+        })
+    }
+
+    fn parse_specialisations(
+        link: &GenerationLink,
+        specialisations: bootspec::Specialisations,
+    ) -> Result<HashMap<SpecialisationName, Generation>> {
+        specialisations
+            .into_iter()
+            .map(|(name, json)| {
+                Self::parse_specialisation(link, name.clone(), json)
+                    .map(|generation| (name, generation))
+            })
+            .collect::<Result<HashMap<SpecialisationName, Generation>>>()
+    }
+
+    fn parse_boot_json(
+        link: &GenerationLink,
+        specialisation_name: Option<SpecialisationName>,
+        boot_json: BootJson,
+    ) -> Result<Self> {
+        let bootspec: BootSpec = boot_json.clone().generation.try_into()?;
 
         Ok(Self {
             version: link.version,
             build_time: link.build_time,
-            specialisation_name: None,
+            specialisation_name,
             spec: ExtendedBootJson {
-                bootspec,
-                lanzaboote_extension,
+                bootspec: bootspec.clone(),
+                lanzaboote_extension: boot_json.into(),
             },
+            specialisations: Self::parse_specialisations(link, bootspec.specialisations)?,
         })
-    }
-
-    pub fn specialise(&self, name: &SpecialisationName, specialisation: &Specialisation) -> Self {
-        Self {
-            specialisation_name: Some(name.clone()),
-            spec: ExtendedBootJson {
-                bootspec: specialisation.generation.clone(),
-                lanzaboote_extension: self.spec.lanzaboote_extension.clone(),
-            },
-            ..self.clone()
-        }
     }
 
     /// A helper for describe functions below.

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -162,9 +162,9 @@ impl<S: Signer> Installer<S> {
             // Thus, this cannot overwrite files of old generation with different content.
             self.install_generation(&generation)
                 .with_context(|| format!("Failed to install generation {}", generation.version))?;
-            for (name, bootspec) in &generation.spec.bootspec.specialisations {
-                let specialised_generation = generation.specialise(name, bootspec);
-                self.install_generation(&specialised_generation)
+
+            for specialisation in generation.specialisations.values() {
+                self.install_generation(specialisation)
                     .context("Failed to install specialisation.")?;
             }
         }

--- a/rust/tool/systemd/tests/integration/common.rs
+++ b/rust/tool/systemd/tests/integration/common.rs
@@ -73,7 +73,35 @@ pub fn setup_generation_link_from_toplevel(
         },
         "org.nix-community.lanzaboote": {
             "sort_key": "lanzaboote",
-        }
+        },
+        "org.nixos.specialisation.v1": {
+          "rescue": {
+            "org.nixos.bootspec.v1": {
+              "init": format!("init-v{}", version),
+              // Normally, these are in the Nix store.
+              "initrd": toplevel.join("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-6.1.1/initrd"),
+              "kernel": toplevel.join("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-6.1.1/kernel"),
+              "kernelParams": [
+                "amd_iommu=on",
+                "amd_iommu=pt",
+                "iommu=pt",
+                "kvm.ignore_msrs=1",
+                "kvm.report_ignored_msrs=0",
+                "udev.log_priority=3",
+                "systemd.unified_cgroup_hierarchy=1",
+                "loglevel=4"
+              ],
+              "label": "LanzaOS",
+              "toplevel": toplevel,
+              "system": SYSTEM,
+            },
+            "org.nix-community.lanzaboote": {
+                "sort_key": "lanzaboote2",
+            },
+            "org.nixos.specialisation.v1": {
+            },
+          },
+        },
     });
 
     let generation_link_path = profiles_directory.join(format!("system-{}-link", version));

--- a/rust/tool/systemd/tests/integration/gc.rs
+++ b/rust/tool/systemd/tests/integration/gc.rs
@@ -24,7 +24,7 @@ fn keep_only_configured_number_of_generations() -> Result<()> {
     // Install all 3 generations.
     let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), generation_links.clone())?;
     assert!(output0.status.success());
-    assert_eq!(stub_count(), 3, "Wrong number of stubs after installation");
+    assert_eq!(stub_count(), 6, "Wrong number of stubs after installation");
     assert_eq!(
         kernel_and_initrd_count(),
         2,
@@ -35,7 +35,7 @@ fn keep_only_configured_number_of_generations() -> Result<()> {
     // In addition, the garbage kernel should be deleted as well.
     let output1 = common::lanzaboote_install(2, esp_mountpoint.path(), generation_links)?;
     assert!(output1.status.success());
-    assert_eq!(stub_count(), 2, "Wrong number of stubs after gc.");
+    assert_eq!(stub_count(), 4, "Wrong number of stubs after gc.");
     assert_eq!(
         kernel_and_initrd_count(),
         2,
@@ -75,7 +75,7 @@ fn delete_garbage_kernel() -> Result<()> {
     let output1 = common::lanzaboote_install(2, esp_mountpoint.path(), generation_links)?;
     assert!(output1.status.success());
 
-    assert_eq!(stub_count(), 2, "Wrong number of stubs after gc.");
+    assert_eq!(stub_count(), 4, "Wrong number of stubs after gc.");
     assert_eq!(
         kernel_and_initrd_count(),
         2,

--- a/rust/tool/systemd/tests/integration/install.rs
+++ b/rust/tool/systemd/tests/integration/install.rs
@@ -25,7 +25,7 @@ fn do_not_install_duplicates() -> Result<()> {
 
     let output1 = common::lanzaboote_install(0, esp.path(), generation_links)?;
     assert!(output1.status.success());
-    assert_eq!(stub_count(), 2, "Wrong number of stubs after installation");
+    assert_eq!(stub_count(), 4, "Wrong number of stubs after installation");
     assert_eq!(
         kernel_and_initrd_count(),
         2,


### PR DESCRIPTION
This fixes https://github.com/DeterminateSystems/bootspec/issues/147 by bumping the bootspec to the latest version.
Upstream PR: https://github.com/DeterminateSystems/bootspec/pull/207

This means that we now capture the full recursive JSON schema for specialisations, including extensions, while the previous type threw this information away.

This is essential for features like boot counting so that users can set separate sort keys for specialisations, to avoid the boot loader falling back to specialisations when a new generation fails to boot.
Often specialisations are special cases that we don't want to boot automatically, so they can now be sorted below all normal generations so that if a generation fails to boot, the boot loader will fall back onto the previous generation.

CC: @blitz @raitobezarius
