### PR TITLE
feat: Allow multiple ESPs for installation

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -24,6 +24,7 @@ in
   systemd-boot-loader-config = runTest ./lanzaboote/systemd-boot-loader-config.nix;
   export-efivars = runTest ./lanzaboote/export-efivars.nix;
   export-efivars-tpm = runTest ./lanzaboote/export-efivars-tpm.nix;
+  extra-efi-partitions = runTest ./lanzaboote/extra-efi-partitions.nix;
 
   systemd-pcrlock = runTest ./lanzaboote/systemd-pcrlock.nix;
   systemd-measured-uki = runTest ./lanzaboote/systemd-measured-uki.nix;

--- a/nix/tests/lanzaboote/extra-efi-partitions.nix
+++ b/nix/tests/lanzaboote/extra-efi-partitions.nix
@@ -1,0 +1,26 @@
+{
+
+  name = "lanzaboote-extra-efi-partitions";
+
+  nodes.machine = {
+    imports = [ ./common/lanzaboote.nix ];
+
+    boot.lanzaboote = {
+      extraEfiSysMountPoints = [ "/boot2" ];
+    };
+    # We need this so switch-to-configuration exists and can set up /boot2
+    system.switch.enable = true;
+  };
+
+  testScript =
+    { nodes, ... }:
+    (import ./common/image-helper.nix { inherit (nodes) machine; })
+    + ''
+      # Prepare secondary "ESP" with files
+      machine.succeed("mkdir -p /nix/var/nix/profiles && ln -s ${nodes.machine.system.build.toplevel} /nix/var/nix/profiles/system-1-link")
+      machine.succeed("/run/current-system/bin/switch-to-configuration boot")
+      # Similar to basic.nix test, except ensure we have copies of the relevant files on both EFI partitions.
+      t.assertIn("Kernel Type: uki", machine.succeed("bootctl kernel-inspect /boot/EFI/Linux/nixos-generation-1-*.efi"))
+      t.assertIn("Kernel Type: uki", machine.succeed("bootctl kernel-inspect /boot2/EFI/Linux/nixos-generation-1-*.efi"))
+    '';
+}


### PR DESCRIPTION
Running this locally (on all my machines) currently, so can confirm it does fully work in the real world, too.

This is for use in a scenario where you have multiple boot drives in a software RAID scenario. The root partition can of course be handled by `swraid` / `mdraid`, however UEFI expect raw FAT32 partitions to exist.

This can be "fudged" with using metadata-at-end, but that is fragile and relies on the end of the FAT32 partition to stay blank.

The much safer method, proposed here, just repeats installation steps against both ESPs, avoiding any issues.