### PR TITLE
fix: Updated conditionPathExists for generate-sb-keys.

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -263,7 +263,11 @@ in
       wantedBy = [ "multi-user.target" ];
 
       unitConfig = {
-        ConditionPathExists = "!${cfg.pkiBundle}";
+        # Check to make sure keys directory is not present. Needs to check for
+        # a subdirectory of pkiBundle as typically in impermanence-based configs
+        # pkiBundle will be persisted, so it will always exist and is not
+        # a true determination of whether keys have been generated previously.
+        ConditionPathExists = "!${cfg.pkiBundle}/keys";
       };
 
       serviceConfig = {


### PR DESCRIPTION
Fixes issue described in #520 whereby generate-sb-keys service won't ever trigger on a host that uses impermanence and has /var/lib/sbctl persisted. Instead of a condition based on pkiBundle, it looks for presence of pkiBundle/keys. 