### PR TITLE
Modify Secure Boot key enrollment command

### DIFF
--- a/docs/getting-started/enable-secure-boot.md
+++ b/docs/getting-started/enable-secure-boot.md
@@ -62,9 +62,10 @@ your keys to activate Secure Boot. We include Microsoft keys here to
 avoid boot issues.
 
 ```console
-$ sudo sbctl enroll-keys --microsoft
+$ sudo sbctl enroll-keys --microsoft  --firmware-builtin
 Enrolling keys to EFI variables...
-With vendor keys from microsoft...✓
+With vendor keys from microsoft...
+With vendor certificates built into the firmware...✓
 Enrolled keys to the EFI variables!
 ```
 


### PR DESCRIPTION
Hello, I follow this guide at home and fount out that a command from the wiki was missing.

Updated command to include --firmware-builtin option for enrolling Microsoft keys.

This is based on https://wiki.nixos.org/wiki/Limine