### PR TITLE
Add support for multiple NixOS system profiles

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -25,6 +25,31 @@ let
   mkInstallCommand =
     efiSysMountPoint:
     ''
+      prof_dir="/nix/var/nix/profiles" profiles=""
+
+      # Add all default system profiles, if any
+      if [ "$(${lib.getExe pkgs.findutils} "$prof_dir" -type l -name 'system-*-link' \
+              | ${lib.getExe' pkgs.coreutils "wc"} -l)" -gt 0 ]; then
+        profiles+="$prof_dir/system-*-link "
+      fi
+
+      # Add all extra system profiles, if any
+      if [ -d "$prof_dir/system-profiles" ] &&
+          [ "$(${lib.getExe pkgs.findutils} \
+                 "$prof_dir/system-profiles" -type l -name '*-*-link' \
+               | ${lib.getExe' pkgs.coreutils "wc"} -l)" -gt 0 ]; then
+        profiles+="$prof_dir/system-profiles/*-*-link"
+      fi
+
+      # Display a clear error message if no usable profile can be found
+      if [ "$profiles" = "" ]; then
+        ${lib.getExe' pkgs.coreutils "printf"} "%s %s %s\n" \
+          "Failed to find usable system profiles. Please make sure that" \
+          "system profiles are present under $prof_dir/system-*-link and/or" \
+          "$prof_dir/system-profiles/<profile-name>-*-link." 1>&2
+        exit 1
+      fi
+
       PATH=${config.systemd.package}/lib/systemd:$PATH
       ${cfg.installCommand} \
     ''
@@ -41,7 +66,7 @@ let
           efiSysMountPoint
         ]
       )
-      + " /nix/var/nix/profiles/system-*-link"
+      + " $profiles"
     );
 
   installHook = pkgs.writeShellScriptBin "lzbt" (

--- a/rust/tool/shared/src/os_release.rs
+++ b/rust/tool/shared/src/os_release.rs
@@ -38,8 +38,9 @@ impl OsRelease {
         map.insert(
             "PRETTY_NAME".into(),
             format!(
-                "{} ({})",
+                "{}{} ({})",
                 generation.spec.bootspec.bootspec.label,
+                generation.describe_profile(),
                 generation.describe()
             ),
         );

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -548,24 +548,31 @@ fn stub_prefix<S: Signer>(generation: &Generation, signer: &S) -> Result<String>
         // Generation numbers can be reused if the latest generation was deleted.
         // To detect this, the stub path depends on the actual toplevel used.
         ("toplevel", bootspec.toplevel.0.as_os_str().as_bytes()),
-        // If the key is rotated, the signed stubs must be re-generated.
+        // If the key is rotated, the signed stubs must be regenerated.
         // So we make their path depend on the public key used for signature.
         ("public_key", &public_key),
     ];
     let stub_input_hash = Base32Unpadded::encode_string(&Sha256::digest(
         serde_json::to_string(&stub_inputs).unwrap(),
     ));
+
+    let mut efi_name = String::from("nixos");
+    if &generation.profile != "system" {
+        efi_name.push_str(&format!("-{}", &generation.profile));
+    };
     if let Some(specialisation_name) = &generation.specialisation_name {
-        Ok(format!(
-            "nixos-generation-{}-specialisation-{}-{}",
+        efi_name.push_str(&format!(
+            "-generation-{}-specialisation-{}-{}",
             generation, specialisation_name, stub_input_hash
-        ))
+        ));
     } else {
-        Ok(format!(
-            "nixos-generation-{}-{}",
+        efi_name.push_str(&format!(
+            "-generation-{}-{}",
             generation, stub_input_hash
-        ))
+        ));
     }
+
+    Ok(efi_name)
 }
 
 /// Install a PE file. The PE gets signed in the process.

--- a/rust/tool/systemd/tests/integration/gc.rs
+++ b/rust/tool/systemd/tests/integration/gc.rs
@@ -1,5 +1,5 @@
-use std::fs;
 use std::path::PathBuf;
+use std::{fs, usize};
 
 use anyhow::Result;
 use tempfile::tempdir;
@@ -11,36 +11,69 @@ fn keep_only_configured_number_of_generations() -> Result<()> {
     let esp_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
-    let generation_links: Vec<PathBuf> = [1, 2, 3]
-        .into_iter()
-        .map(|v| {
-            common::setup_generation_link(tmpdir.path(), profiles.path(), v)
-                .expect("Failed to setup generation link")
-        })
-        .collect();
     let stub_count = || count_files(&esp_mountpoint.path().join("EFI/Linux")).unwrap();
     let kernel_and_initrd_count = || count_files(&esp_mountpoint.path().join("EFI/nixos")).unwrap();
 
-    // Install all 3 generations.
-    let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), generation_links.clone())?;
-    assert!(output0.status.success());
-    assert_eq!(stub_count(), 6, "Wrong number of stubs after installation");
-    assert_eq!(
-        kernel_and_initrd_count(),
-        2,
-        "Wrong number of kernels & initrds after installation"
-    );
+    let kp_configured_num_gen =
+        |gen_lnks: Vec<PathBuf>, n_gens: usize, config_lim: usize| -> Result<()> {
+            // Install all generations.
+            let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), gen_lnks.clone())?;
+            assert!(output0.status.success());
+            assert_eq!(
+                stub_count(),
+                2 * n_gens,
+                "Wrong number of stubs after installation"
+            );
+            assert_eq!(
+                kernel_and_initrd_count(),
+                2,
+                "Wrong number of kernels & initrds after installation"
+            );
 
-    // Call `lanzatool install` again with a config limit of 2 and assert that one is deleted.
-    // In addition, the garbage kernel should be deleted as well.
-    let output1 = common::lanzaboote_install(2, esp_mountpoint.path(), generation_links)?;
-    assert!(output1.status.success());
-    assert_eq!(stub_count(), 4, "Wrong number of stubs after gc.");
-    assert_eq!(
-        kernel_and_initrd_count(),
-        2,
-        "Wrong number of kernels & initrds after gc."
-    );
+            // Call `lanzatool install` again with a config limit and assert that the rest are deleted.
+            // In addition, the garbage kernel should be deleted as well.
+            let output1 = common::lanzaboote_install(
+                config_lim.try_into().unwrap(),
+                esp_mountpoint.path(),
+                gen_lnks,
+            )?;
+            assert!(output1.status.success());
+            assert_eq!(stub_count(), 2 * config_lim, "Wrong number of stubs after gc.");
+            assert_eq!(
+                kernel_and_initrd_count(),
+                2,
+                "Wrong number of kernels & initrds after gc."
+            );
+
+            Ok(())
+        };
+
+    // Without profile
+    let generation_links: Vec<PathBuf> = [1, 2, 3]
+        .into_iter()
+        .map(|v| {
+            common::setup_generation_link(tmpdir.path(), profiles.path(), v, None)
+                .expect("Failed to setup generation link")
+        })
+        .collect();
+    let _ = kp_configured_num_gen(generation_links, usize::from(3u8), usize::from(2u8));
+
+    // With profile
+    let generation_links_prof: Vec<PathBuf> = [
+        ("My Prof 1", 1),
+        ("My Prof 1", 2),
+        ("My-Prof-2", 1),
+        ("My-Prof-2", 2),
+        ("My_Prof_3", 1),
+        ("My_Prof_3", 2),
+    ]
+    .into_iter()
+    .map(|(p, v)| {
+        common::setup_generation_link(tmpdir.path(), profiles.path(), v, Some(p.to_string()))
+            .expect("Failed to setup generation link")
+    })
+    .collect();
+    let _ = kp_configured_num_gen(generation_links_prof, usize::from(6u8), usize::from(4u8));
 
     Ok(())
 }
@@ -50,37 +83,65 @@ fn delete_garbage_kernel() -> Result<()> {
     let esp_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
-    let generation_links: Vec<PathBuf> = [1, 2, 3]
-        .into_iter()
-        .map(|v| {
-            common::setup_generation_link(tmpdir.path(), profiles.path(), v)
-                .expect("Failed to setup generation link")
-        })
-        .collect();
     let stub_count = || count_files(&esp_mountpoint.path().join("EFI/Linux")).unwrap();
     let kernel_and_initrd_count = || count_files(&esp_mountpoint.path().join("EFI/nixos")).unwrap();
 
-    // Install all 3 generations.
-    let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), generation_links.clone())?;
-    assert!(output0.status.success());
+    let del_garb_kern = |gen_lnks: Vec<PathBuf>, config_lim: usize| -> Result<()> {
+        // Install all generations.
+        let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), gen_lnks.clone())?;
+        assert!(output0.status.success());
 
-    // Create a garbage kernel, which should be deleted.
-    fs::write(
-        esp_mountpoint.path().join("EFI/nixos/kernel-garbage.efi"),
-        "garbage",
-    )?;
+        // Create a garbage kernel, which should be deleted.
+        fs::write(
+            esp_mountpoint.path().join("EFI/nixos/kernel-garbage.efi"),
+            "garbage",
+        )?;
 
-    // Call `lanzatool install` again with a config limit of 2.
-    // In addition, the garbage kernel should be deleted as well.
-    let output1 = common::lanzaboote_install(2, esp_mountpoint.path(), generation_links)?;
-    assert!(output1.status.success());
+        // Call `lanzatool install` again with a config limit.
+        // In addition, the garbage kernel should be deleted as well.
+        let output1 = common::lanzaboote_install(
+            config_lim.try_into().unwrap(),
+            esp_mountpoint.path(),
+            gen_lnks,
+        )?;
+        assert!(output1.status.success());
 
-    assert_eq!(stub_count(), 4, "Wrong number of stubs after gc.");
-    assert_eq!(
-        kernel_and_initrd_count(),
-        2,
-        "Wrong number of kernels & initrds after gc."
-    );
+        assert_eq!(stub_count(), 2 * config_lim, "Wrong number of stubs after gc.");
+        assert_eq!(
+            kernel_and_initrd_count(),
+            2,
+            "Wrong number of kernels & initrds after gc."
+        );
+
+        Ok(())
+    };
+
+    // Without profile
+    let generation_links: Vec<PathBuf> = [1, 2, 3]
+        .into_iter()
+        .map(|v| {
+            common::setup_generation_link(tmpdir.path(), profiles.path(), v, None)
+                .expect("Failed to setup generation link")
+        })
+        .collect();
+    let _ = del_garb_kern(generation_links, usize::from(2u8));
+
+    // With profile
+    let generation_links_prof: Vec<PathBuf> = [
+        ("My Prof 1", 1),
+        ("My Prof 1", 2),
+        ("My-Prof-2", 1),
+        ("My-Prof-2", 2),
+        ("My_Prof_3", 1),
+        ("My_Prof_3", 2),
+    ]
+    .into_iter()
+    .map(|(p, v)| {
+        common::setup_generation_link(tmpdir.path(), profiles.path(), v, Some(p.to_string()))
+            .expect("Failed to setup generation link")
+    })
+    .collect();
+    let _ = del_garb_kern(generation_links_prof, usize::from(4u8));
 
     Ok(())
 }
@@ -90,35 +151,63 @@ fn keep_unrelated_files_on_esp() -> Result<()> {
     let esp_mountpoint = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
+
+    let kp_unrel_files = |gen_lnks: Vec<PathBuf>, config_lim: usize| -> Result<()> {
+        // Install all generations.
+        let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), gen_lnks.clone())?;
+        assert!(output0.status.success());
+
+        let unrelated_loader_config = esp_mountpoint.path().join("loader/loader.conf");
+        let unrelated_uki = esp_mountpoint.path().join("EFI/Linux/ubuntu.efi");
+        let unrelated_os = esp_mountpoint.path().join("EFI/windows");
+        let unrelated_firmware = esp_mountpoint.path().join("dell");
+        fs::File::create(&unrelated_loader_config)?;
+        fs::File::create(&unrelated_uki)?;
+        fs::create_dir(&unrelated_os)?;
+        fs::create_dir(&unrelated_firmware)?;
+
+        // Call `lanzatool install` again with a config limit.
+        let output1 = common::lanzaboote_install(
+            config_lim.try_into().unwrap(),
+            esp_mountpoint.path(),
+            gen_lnks,
+        )?;
+        assert!(output1.status.success());
+
+        assert!(unrelated_loader_config.exists());
+        assert!(unrelated_uki.exists());
+        assert!(unrelated_os.exists());
+        assert!(unrelated_firmware.exists());
+
+        Ok(())
+    };
+
+    // Without profile
     let generation_links: Vec<PathBuf> = [1, 2, 3]
         .into_iter()
         .map(|v| {
-            common::setup_generation_link(tmpdir.path(), profiles.path(), v)
+            common::setup_generation_link(tmpdir.path(), profiles.path(), v, None)
                 .expect("Failed to setup generation link")
         })
         .collect();
+    let _ = kp_unrel_files(generation_links, usize::from(2u8));
 
-    // Install all 3 generations.
-    let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), generation_links.clone())?;
-    assert!(output0.status.success());
-
-    let unrelated_loader_config = esp_mountpoint.path().join("loader/loader.conf");
-    let unrelated_uki = esp_mountpoint.path().join("EFI/Linux/ubuntu.efi");
-    let unrelated_os = esp_mountpoint.path().join("EFI/windows");
-    let unrelated_firmware = esp_mountpoint.path().join("dell");
-    fs::File::create(&unrelated_loader_config)?;
-    fs::File::create(&unrelated_uki)?;
-    fs::create_dir(&unrelated_os)?;
-    fs::create_dir(&unrelated_firmware)?;
-
-    // Call `lanzatool install` again with a config limit of 2.
-    let output1 = common::lanzaboote_install(2, esp_mountpoint.path(), generation_links)?;
-    assert!(output1.status.success());
-
-    assert!(unrelated_loader_config.exists());
-    assert!(unrelated_uki.exists());
-    assert!(unrelated_os.exists());
-    assert!(unrelated_firmware.exists());
+    // With profile
+    let generation_links_prof: Vec<PathBuf> = [
+        ("My Prof 1", 1),
+        ("My Prof 1", 2),
+        ("My-Prof-2", 1),
+        ("My-Prof-2", 2),
+        ("My_Prof_3", 1),
+        ("My_Prof_3", 2),
+    ]
+    .into_iter()
+    .map(|(p, v)| {
+        common::setup_generation_link(tmpdir.path(), profiles.path(), v, Some(p.to_string()))
+            .expect("Failed to setup generation link")
+    })
+    .collect();
+    let _ = kp_unrel_files(generation_links_prof, usize::from(4u8));
 
     Ok(())
 }

--- a/rust/tool/systemd/tests/integration/os_release.rs
+++ b/rust/tool/systemd/tests/integration/os_release.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use anyhow::{Context, Result};
-use expect_test::expect;
+use expect_test::{expect, Expect};
 use tempfile::tempdir;
 
 use crate::common;
@@ -13,25 +13,47 @@ fn generate_expected_os_release() -> Result<()> {
     let profiles = tempdir()?;
     let toplevel = common::setup_toplevel(tmpdir.path())?;
 
-    let generation_link =
-        common::setup_generation_link_from_toplevel(&toplevel, profiles.path(), 1)
-            .expect("Failed to setup generation link");
+    let gen_exp_os_rel = |prof: Option<String>, ver: u64, exp: Expect| -> Result<()> {
+        let generation_link = common::setup_generation_link_from_toplevel(
+            &toplevel,
+            profiles.path(),
+            ver,
+            prof.clone(),
+        )
+        .expect("Failed to setup generation link");
 
-    let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), vec![generation_link])?;
-    assert!(output0.status.success());
+        let output0 = common::lanzaboote_install(0, esp_mountpoint.path(), vec![generation_link])?;
+        assert!(output0.status.success());
 
-    let stub_data = fs::read(common::image_path(&esp_mountpoint, 1, &toplevel)?)?;
-    let os_release_section = pe_section(&stub_data, ".osrel")
-        .context("Failed to read .osrelease PE section.")?
-        .to_owned();
+        let stub_data = fs::read(common::image_path(&esp_mountpoint, ver, prof, &toplevel)?)?;
+        let os_release_section = pe_section(&stub_data, ".osrel")
+            .context("Failed to read .osrelease PE section.")?
+            .to_owned();
 
+        exp.assert_eq(&String::from_utf8(os_release_section)?);
+
+        Ok(())
+    };
+
+    // Without profile
     let expected = expect![[r#"
         ID=lanzaboote
         PRETTY_NAME=LanzaOS (Generation 1, 1970-01-01)
         VERSION_ID=Generation 1, 1970-01-01
     "#]];
+    let _ = gen_exp_os_rel(None, 1u64, expected);
 
-    expected.assert_eq(&String::from_utf8(os_release_section)?);
+    // With profile
+    let expected_prof = expect![[r#"
+        ID=lanzaboote
+        PRETTY_NAME=LanzaOS [My W#@cky_Yet_L3g!t profile-name -3] (Generation 1, 1970-01-01)
+        VERSION_ID=Generation 1, 1970-01-01
+    "#]];
+    let _ = gen_exp_os_rel(
+        Some("My W#@cky_Yet_L3g!t profile-name -3".to_string()),
+        1u64,
+        expected_prof,
+    );
 
     Ok(())
 }

--- a/rust/tool/systemd/tests/integration/systemd_boot.rs
+++ b/rust/tool/systemd/tests/integration/systemd_boot.rs
@@ -13,34 +13,46 @@ fn keep_systemd_boot_binaries() -> Result<()> {
     let esp = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
-    let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
-        .expect("Failed to setup generation link");
 
     let systemd_boot_path = systemd_boot_path(&esp);
     let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
 
-    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
-    assert!(output0.status.success());
+    let kp_sys_boot_bins = |prof: Option<String>| -> Result<()> {
+        let generation_link =
+            common::setup_generation_link(tmpdir.path(), profiles.path(), 1, prof)
+                .expect("Failed to setup generation link");
 
-    // Use the modification time instead of a hash because the hash would be the same even if the
-    // file was overwritten.
-    let systemd_boot_mtime0 = mtime(&systemd_boot_path);
-    let systemd_boot_fallback_mtime0 = mtime(&systemd_boot_fallback_path);
+        let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+        assert!(output0.status.success());
 
-    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
-    assert!(output1.status.success());
+        // Use the modification time instead of a hash because the hash would be the same even if the
+        // file was overwritten.
+        let systemd_boot_mtime0 = mtime(&systemd_boot_path);
+        let systemd_boot_fallback_mtime0 = mtime(&systemd_boot_fallback_path);
 
-    let systemd_boot_mtime1 = mtime(&systemd_boot_path);
-    let systemd_boot_fallback_mtime1 = mtime(&systemd_boot_fallback_path);
+        let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+        assert!(output1.status.success());
 
-    assert_eq!(
-        systemd_boot_mtime0, systemd_boot_mtime1,
-        "systemd-boot binary was modified on second install."
-    );
-    assert_eq!(
-        systemd_boot_fallback_mtime0, systemd_boot_fallback_mtime1,
-        "systemd-boot fallback binary was moidified on second install."
-    );
+        let systemd_boot_mtime1 = mtime(&systemd_boot_path);
+        let systemd_boot_fallback_mtime1 = mtime(&systemd_boot_fallback_path);
+
+        assert_eq!(
+            systemd_boot_mtime0, systemd_boot_mtime1,
+            "systemd-boot binary was modified on second install."
+        );
+        assert_eq!(
+            systemd_boot_fallback_mtime0, systemd_boot_fallback_mtime1,
+            "systemd-boot fallback binary was moidified on second install."
+        );
+
+        Ok(())
+    };
+
+    // Without profile
+    let _ = kp_sys_boot_bins(None);
+
+    // With profile
+    let _ = kp_sys_boot_bins(Some("MyProfile".to_string()));
 
     Ok(())
 }
@@ -50,36 +62,48 @@ fn overwrite_malformed_systemd_boot_binaries() -> Result<()> {
     let esp = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
-    let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
-        .expect("Failed to setup generation link");
 
     let systemd_boot_path = systemd_boot_path(&esp);
     let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
 
-    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
-    assert!(output0.status.success());
+    let ow_mal_sys_boot_bins = |prof: Option<String>| -> Result<()> {
+        let generation_link =
+            common::setup_generation_link(tmpdir.path(), profiles.path(), 1, prof)
+                .expect("Failed to setup generation link");
 
-    // Make systemd-boot binaries malformed by truncating them.
-    fs::File::create(&systemd_boot_path)?;
-    fs::File::create(&systemd_boot_fallback_path)?;
+        let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+        assert!(output0.status.success());
 
-    let malformed_systemd_boot_hash = hash_file(&systemd_boot_path);
-    let malformed_systemd_boot_fallback_hash = hash_file(&systemd_boot_fallback_path);
+        // Make systemd-boot binaries malformed by truncating them.
+        fs::File::create(&systemd_boot_path)?;
+        fs::File::create(&systemd_boot_fallback_path)?;
 
-    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
-    assert!(output1.status.success());
+        let malformed_systemd_boot_hash = hash_file(&systemd_boot_path);
+        let malformed_systemd_boot_fallback_hash = hash_file(&systemd_boot_fallback_path);
 
-    let systemd_boot_hash = hash_file(&systemd_boot_path);
-    let systemd_boot_fallback_hash = hash_file(&systemd_boot_fallback_path);
+        let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+        assert!(output1.status.success());
 
-    assert_ne!(
-        malformed_systemd_boot_hash, systemd_boot_hash,
-        "Malformed systemd-boot binaries were not replaced."
-    );
-    assert_ne!(
-        malformed_systemd_boot_fallback_hash, systemd_boot_fallback_hash,
-        "Maformed systemd-boot fallback binaries were not replaced."
-    );
+        let systemd_boot_hash = hash_file(&systemd_boot_path);
+        let systemd_boot_fallback_hash = hash_file(&systemd_boot_fallback_path);
+
+        assert_ne!(
+            malformed_systemd_boot_hash, systemd_boot_hash,
+            "Malformed systemd-boot binaries were not replaced."
+        );
+        assert_ne!(
+            malformed_systemd_boot_fallback_hash, systemd_boot_fallback_hash,
+            "Maformed systemd-boot fallback binaries were not replaced."
+        );
+
+        Ok(())
+    };
+
+    // Without profile
+    let _ = ow_mal_sys_boot_bins(None);
+
+    // With profile
+    let _ = ow_mal_sys_boot_bins(Some("MyProfile".to_string()));
 
     Ok(())
 }
@@ -89,25 +113,37 @@ fn overwrite_unsigned_systemd_boot_binaries() -> Result<()> {
     let esp = tempdir()?;
     let tmpdir = tempdir()?;
     let profiles = tempdir()?;
-    let generation_link = common::setup_generation_link(tmpdir.path(), profiles.path(), 1)
-        .expect("Failed to setup generation link");
 
     let systemd_boot_path = systemd_boot_path(&esp);
     let systemd_boot_fallback_path = systemd_boot_fallback_path(&esp);
 
-    let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
-    assert!(output0.status.success());
+    let ow_unsign_sys_boot_bins = |prof: Option<String>| -> Result<()> {
+        let generation_link =
+            common::setup_generation_link(tmpdir.path(), profiles.path(), 1, prof)
+                .expect("Failed to setup generation link");
 
-    remove_signature(&systemd_boot_path)?;
-    remove_signature(&systemd_boot_fallback_path)?;
-    assert!(!verify_signature(&systemd_boot_path)?);
-    assert!(!verify_signature(&systemd_boot_fallback_path)?);
+        let output0 = common::lanzaboote_install(0, esp.path(), vec![&generation_link])?;
+        assert!(output0.status.success());
 
-    let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
-    assert!(output1.status.success());
+        remove_signature(&systemd_boot_path)?;
+        remove_signature(&systemd_boot_fallback_path)?;
+        assert!(!verify_signature(&systemd_boot_path)?);
+        assert!(!verify_signature(&systemd_boot_fallback_path)?);
 
-    assert!(verify_signature(&systemd_boot_path)?);
-    assert!(verify_signature(&systemd_boot_fallback_path)?);
+        let output1 = common::lanzaboote_install(0, esp.path(), vec![generation_link])?;
+        assert!(output1.status.success());
+
+        assert!(verify_signature(&systemd_boot_path)?);
+        assert!(verify_signature(&systemd_boot_fallback_path)?);
+
+        Ok(())
+    };
+
+    // Without profile
+    let _ = ow_unsign_sys_boot_bins(None);
+
+    // With profile
+    let _ = ow_unsign_sys_boot_bins(Some("MyProfile".to_string()));
 
     Ok(())
 }


### PR DESCRIPTION
Hey everyone. This PR attempts to  add  support for NixOS system profiles to lanzaboote. I had originally written this patch at around August of 2025 for personal use but the folks over at #135 have encouraged me to create a PR here.

Here's a list of the most important changes:

- Get profile names from `system-profiles/` while also being compatible with non-profiled systems
- Since profile names can also have `-` characters, handle any stray `-`s so versions and profile names can be safely extracted
- Add profile names to the `.efi` entries as well as in boot menus in a fashion consistent with `systemd-boot`
- Update the unit and integration tests to accommodate the presence and absence of profiles

I must add that I didn't know any Rust and sorta hacked my way around when I made these changes, following compiler hints and warnings. So, the quality of the my modifications may not be the best. I would, hence, be welcoming of any suggestions aimed towards improving the quality of this patch.

P.S. Here's an image of what the boot menu looks like after my changes (profile names are inside square brackets):

<img width="3704" height="853" alt="image" src="https://github.com/user-attachments/assets/25cc6f5b-03fd-42bc-af1a-ede4c8726c33" />

- Entry 1 belongs to the default profile, aka the `system` profile.
- Entry 2 belongs to the `Workstation` profile
- Entry 3 belongs to the `Gamestation` profile