### PR TITLE
TPM2 PCR Signatures

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -17,10 +17,7 @@ let
 
   configurationLimit = if cfg.configurationLimit == null then 0 else cfg.configurationLimit;
 
-  efiSysMountPoints = [
-    espMountPoint
-  ]
-  ++ cfg.extraEfiSysMountPoints;
+  efiSysMountPoints = [ espMountPoint ] ++ cfg.extraEfiSysMountPoints;
 
   mkInstallCommand =
     efiSysMountPoint:
@@ -37,9 +34,7 @@ let
         ++ lib.optionals (cfg.measuredBoot.enable && pcr 4) [
           "--pcrlock-directory=${cfg.measuredBoot.pcrlockDirectory}"
         ]
-        ++ [
-          efiSysMountPoint
-        ]
+        ++ [ efiSysMountPoint ]
       )
       + " /nix/var/nix/profiles/system-*-link"
     );
@@ -88,6 +83,12 @@ let
     ]
     ++ lib.map (pcr: "--pcr=${toString pcr}") cfg.measuredBoot.pcrs
   );
+
+  pcrSignatureConfigFile =
+    if cfg.measuredBoot.pcrSignatures == [ ] then
+      null
+    else
+      json.generate "lanzaboote-pcr-signing-config.json" cfg.measuredBoot.pcrSignatures;
 in
 {
   imports = [
@@ -140,9 +141,7 @@ in
     };
 
     settings = lib.mkOption {
-      type = lib.types.submodule {
-        freeformType = loaderSettingsFormat.type;
-      };
+      type = lib.types.submodule { freeformType = loaderSettingsFormat.type; };
 
       apply = lib.recursiveUpdate options.boot.lanzaboote.settings.default;
 
@@ -152,9 +151,7 @@ in
         editor = config.boot.loader.systemd-boot.editor;
         default = "nixos-*";
       }
-      // lib.optionalAttrs cfg.autoEnrollKeys.enable {
-        secure-boot-enroll = "force";
-      };
+      // lib.optionalAttrs cfg.autoEnrollKeys.enable { secure-boot-enroll = "force"; };
 
       defaultText = ''
         {
@@ -234,7 +231,10 @@ in
           --systemd-boot-loader-config ${loaderConfigFile} \
           --configuration-limit ${toString configurationLimit} \
           --allow-unsigned ${lib.boolToString cfg.allowUnsigned} \
-          --bootcounting-initial-tries ${toString cfg.bootCounting.initialTries}'';
+          --bootcounting-initial-tries ${toString cfg.bootCounting.initialTries} \
+          ${lib.optionalString (
+            pcrSignatureConfigFile != null
+          ) "--pcr-signature-config ${pcrSignatureConfigFile}"}'';
       defaultText = lib.literalExpression ''
         ''${lib.getExe config.boot.lanzaboote.package} ''${lib.optionalString (config.boot.lanzaboote.logLevel == "debug") "-vv"} install \
           --system ''${config.boot.kernelPackages.stdenv.hostPlatform.system} \
@@ -242,7 +242,10 @@ in
           --systemd-boot-loader-config ''${loaderConfigFile} \
           --configuration-limit ''${toString configurationLimit} \
           --allow-unsigned ''${lib.boolToString config.boot.lanzaboote.allowUnsigned} \
-          --bootcounting-initial-tries ''${toString config.boot.lanzaboote.bootCounting.initialTries}'';
+          --bootcounting-initial-tries ''${toString config.boot.lanzaboote.bootCounting.initialTries} \
+          ''${lib.optionalString (
+            pcrSignatureConfigFile != null
+          ) "--pcr-signature-config ''${pcrSignatureConfigFile}"}'';
     };
 
     extraEfiSysMountPoints = lib.mkOption {
@@ -411,6 +414,63 @@ in
           '';
         };
       };
+
+      pcrSignatures = lib.mkOption {
+        type = lib.types.listOf (
+          lib.types.submodule {
+            options = {
+              privateKeyFile = lib.mkOption {
+                type = lib.types.path;
+                description = ''
+                  Private key to sign PCR policies.
+
+                  A key pair may be generated with `openssl` with the following commands:
+                  ```bash
+                  openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out tpm2-pcr-private-key.pem
+                  openssl rsa -pubout -in tpm2-pcr-private-key.pem -out tpm2-pcr-public-key.pem
+                  ```
+                '';
+                example = "/etc/systemd/tpm2-pcr-private-key.pem";
+              };
+              phases = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                description = ''
+                  Boot phase paths (colon-separated) to sign a PCR policy for.
+                  If empty, defaults to default phases of `systemd-measure(1)`.
+
+                  Note: By default NixOS does not measure boot phases into PCR 11. See `systemd-pcrphase.service(8)`.
+                '';
+                default = [ "enter-initrd" ];
+                example = [
+                  "enter-initrd"
+                  "enter-initrd:leave-initrd"
+                ];
+              };
+              banks = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                description = ''
+                  PCR banks to sign a PCR policy for.
+                  If empty, defaults to default banks of `systemd-measure(1)`.
+                '';
+                default = [ ];
+                example = [ "sha256" ];
+              };
+            };
+          }
+        );
+        description = "PCR signature configurations used to sign PCR policies with `systemd-measure`.";
+        default = [ ];
+        example = [
+          {
+            privateKeyFile = "/etc/systemd/tpm2-pcr-private-key.pem";
+            banks = [ "sha256" ];
+          }
+          {
+            privateKeyFile = "/etc/systemd/tpm2-pcr-initrd-private-key.pem";
+            phases = [ "enter-initrd" ];
+          }
+        ];
+      };
     };
   };
 
@@ -453,18 +513,12 @@ in
       lib.optionals (pcr 0 || pcr 1 || pcr 2 || pcr 3 || pcr 4) [
         "500-separator.pcrlock.d/300-0x00000000.pcrlock"
       ]
-      ++ lib.optionals (pcr 4) [
-        "350-action-efi-application.pcrlock"
-      ]
-      ++ lib.optionals (pcr 7) [
-        "400-secureboot-separator.pcrlock.d/300-0x00000000.pcrlock"
-      ];
+      ++ lib.optionals (pcr 4) [ "350-action-efi-application.pcrlock" ]
+      ++ lib.optionals (pcr 7) [ "400-secureboot-separator.pcrlock.d/300-0x00000000.pcrlock" ];
 
-    environment.etc."sbctl/sbctl.conf" =
-      lib.mkIf (cfg.autoGenerateKeys.enable || cfg.autoEnrollKeys.enable)
-        {
-          source = sbctlConfigFile;
-        };
+    environment.etc."sbctl/sbctl.conf" = lib.mkIf (
+      cfg.autoGenerateKeys.enable || cfg.autoEnrollKeys.enable
+    ) { source = sbctlConfigFile; };
 
     # Write this to /etc so that manually calling systemd-pcrlock by the user
     # still works without them having to specify the directory.
@@ -504,12 +558,8 @@ in
     };
     systemd.targets.sysinit = lib.mkIf cfg.measuredBoot.enable {
       wants =
-        lib.optionals (pcr 0 || pcr 2) [
-          "systemd-pcrlock-firmware-code.service"
-        ]
-        ++ lib.optionals (pcr 1 || pcr 3) [
-          "systemd-pcrlock-firmware-config.service"
-        ]
+        lib.optionals (pcr 0 || pcr 2) [ "systemd-pcrlock-firmware-code.service" ]
+        ++ lib.optionals (pcr 1 || pcr 3) [ "systemd-pcrlock-firmware-config.service" ]
         ++ lib.optionals (pcr 7) [
           "systemd-pcrlock-secureboot-policy.service"
           "systemd-pcrlock-secureboot-authority.service"
@@ -565,9 +615,7 @@ in
             [ "--export auth" ]
             ++ lib.optionals cfg.autoEnrollKeys.includeMicrosoftKeys [ "--microsoft" ]
             ++ lib.optionals cfg.autoEnrollKeys.includeChecksumsFromTPM [ "--tpm-eventlog" ]
-            ++ lib.optionals cfg.autoEnrollKeys.allowBrickingMyMachine [
-              "--yes-this-might-brick-my-machine"
-            ]
+            ++ lib.optionals cfg.autoEnrollKeys.allowBrickingMyMachine [ "--yes-this-might-brick-my-machine" ]
           );
         in
         ''
@@ -644,6 +692,24 @@ in
 
     services.fwupd.uefiCapsuleSettings = lib.mkIf config.services.fwupd.enable {
       DisableShimForSecureBoot = true;
+    };
+
+    # Copy stub provided metadata from /.extra into /run/, so that it will survive the initrd stage.
+    # systemd-cryptsetup requires the persisted tpm2-pcr-signature.json when used after the initrd.
+    # Source: https://github.com/systemd/systemd/blob/v259.1/tmpfiles.d/20-systemd-stub.conf.in
+    boot.initrd.systemd.tmpfiles.settings."20-lanzaboote-stub" = {
+      "/run/systemd/tpm2-pcr-signature.json".C = {
+        mode = "0444";
+        user = "root";
+        group = "root";
+        argument = "/.extra/tpm2-pcr-signature.json";
+      };
+      "/run/systemd/tpm2-pcr-public-key.pem".C = {
+        mode = "0444";
+        user = "root";
+        group = "root";
+        argument = "/.extra/tpm2-pcr-public-key.pem";
+      };
     };
   };
 }

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -33,4 +33,5 @@ in
   systemd-pcrlock = runTest ./lanzaboote/systemd-pcrlock.nix;
   systemd-measure = runTest ./lanzaboote/systemd-measure.nix;
   systemd-measured-uki = runTest ./lanzaboote/systemd-measured-uki.nix;
+  systemd-cryptsetup-tpm2-signature = runTest ./lanzaboote/systemd-cryptsetup-tpm2-signature.nix;
 }

--- a/nix/tests/lanzaboote/common/image.nix
+++ b/nix/tests/lanzaboote/common/image.nix
@@ -32,7 +32,7 @@ let
     ''
       mkdir -p $out
       ln -s ${config.system.build.toplevel} system-1-link
-      ${cfg.installCommand} \
+      PATH=${config.systemd.package}/lib/systemd:$PATH ${cfg.installCommand} \
     ''
     + (
       if config.lanzabooteTest.keyFixture then

--- a/nix/tests/lanzaboote/systemd-cryptsetup-tpm2-signature.nix
+++ b/nix/tests/lanzaboote/systemd-cryptsetup-tpm2-signature.nix
@@ -1,0 +1,126 @@
+{
+  name = "systemd-cryptsetup-tpm2-signature";
+
+  nodes.machine =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      # Private keys must be in the Nix Store because the stub is installed by ./common/image.nix on the host
+      privateKeyFile = pkgs.runCommand "tpm2-pcr-private-key.pem" { } ''
+        ${lib.getExe pkgs.openssl} genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out $out
+      '';
+      publicKeyFile = pkgs.runCommand "tpm2-pcr-public-key.pem" { } ''
+        ${lib.getExe pkgs.openssl} rsa -pubout -in ${privateKeyFile} -out $out
+      '';
+      privateKeyInitrdFile = pkgs.runCommand "tpm2-pcr-initrd-private-key.pem" { } ''
+        ${lib.getExe pkgs.openssl} genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out $out
+      '';
+      publicKeyInitrdFile = pkgs.runCommand "tpm2-pcr-initrd-public-key.pem" { } ''
+        ${lib.getExe pkgs.openssl} rsa -pubout -in ${privateKeyInitrdFile} -out $out
+      '';
+    in
+    {
+      imports = [ ./common/lanzaboote.nix ];
+
+      virtualisation.tpm.enable = true;
+      virtualisation.emptyDiskImages = [
+        {
+          driveConfig = {
+            name = "crypt-1";
+          };
+          size = 32;
+        }
+        {
+          driveConfig = {
+            name = "crypt-2";
+          };
+          size = 32;
+        }
+      ];
+
+      boot.initrd.systemd.enable = true;
+      boot.initrd.luks.devices = {
+        crypt-1 = {
+          device = "/dev/disk/by-label/crypt-1";
+          crypttabExtraOpts = [
+            "tpm2-device=auto"
+            "nofail"
+            "headless=true"
+          ];
+        };
+        crypt-2 = {
+          device = "/dev/disk/by-label/crypt-2";
+          crypttabExtraOpts = [
+            "tpm2-device=auto"
+            "nofail"
+            "headless=true"
+          ];
+        };
+      };
+      boot.initrd.systemd.services."systemd-cryptsetup@".before = [
+        "cryptsetup.target"
+        "initrd-switch-root.target"
+      ];
+
+      # Measure boot phases
+      boot.initrd.systemd.storePaths = [ "${config.systemd.package}/lib/systemd/systemd-pcrextend" ];
+      boot.initrd.systemd.additionalUpstreamUnits = [ "systemd-pcrphase-initrd.service" ];
+      boot.initrd.systemd.services.systemd-pcrphase-initrd.wantedBy = [ "initrd.target" ];
+      systemd.additionalUpstreamSystemUnits = [
+        "systemd-pcrphase.service"
+        "systemd-pcrphase-sysinit.service"
+      ];
+
+      boot.lanzaboote.measuredBoot.pcrSignatures = [
+        {
+          inherit privateKeyFile;
+          phases = [
+            "enter-initrd"
+            "enter-initrd:leave-initrd"
+            "enter-initrd:leave-initrd:sysinit"
+            "enter-initrd:leave-initrd:sysinit:ready"
+          ];
+        }
+        { privateKeyFile = privateKeyInitrdFile; }
+      ];
+      environment.systemPackages = [ pkgs.cryptsetup ];
+
+      systemd.tmpfiles.settings = {
+        "10-tpm2-pcr-keys" = {
+          "/etc/systemd/tpm2-pcr-public-key.pem".L.argument = "${publicKeyFile}";
+          "/etc/systemd/tpm2-pcr-initrd-public-key.pem".L.argument = "${publicKeyInitrdFile}";
+        };
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    (import ./common/image-helper.nix { inherit (nodes) machine; })
+    + ''
+      machine.wait_for_unit("default.target")
+
+      # Setup LUKS devices
+      machine.succeed("echo 1234 | cryptsetup luksFormat /dev/vdb - --label crypt-1")
+      machine.succeed("echo 123456 | cryptsetup luksFormat /dev/vdc - --label crypt-2")
+      # Enroll TPM2 keys
+      machine.succeed("echo 1234 | systemd-cryptenroll --unlock-key-file=/dev/stdin --tpm2-device=auto --tpm2-public-key=/etc/systemd/tpm2-pcr-public-key.pem --tpm2-public-key-pcrs=11 /dev/disk/by-label/crypt-1")
+      machine.succeed("echo 123456 | systemd-cryptenroll --unlock-key-file=/dev/stdin --tpm2-device=auto --tpm2-public-key=/etc/systemd/tpm2-pcr-initrd-public-key.pem --tpm2-public-key-pcrs=11 /dev/disk/by-label/crypt-2")
+
+      # Unlock disk
+      machine.succeed("systemd-cryptsetup attach crypt-1 /dev/disk/by-label/crypt-1 - tpm2-device=auto,headless=true")
+      # Fail to unlock disk bound to initrd key
+      machine.fail("systemd-cryptsetup attach crypt-2 /dev/disk/by-label/crypt-2 - tpm2-device=auto,headless=true")
+
+      machine.reboot()
+      machine.wait_for_unit("default.target")
+
+      # Check for unlocked LUKS volumes
+      machine.succeed("test -e /dev/mapper/crypt-1")
+      machine.succeed("test -e /dev/mapper/crypt-2")
+      #
+    '';
+}

--- a/rust/tool/shared/src/lib.rs
+++ b/rust/tool/shared/src/lib.rs
@@ -3,6 +3,7 @@ pub mod esp;
 pub mod gc;
 pub mod generation;
 pub mod os_release;
+pub mod pcr_signature;
 pub mod pe;
 pub mod signature;
 pub mod utils;

--- a/rust/tool/shared/src/pcr_signature.rs
+++ b/rust/tool/shared/src/pcr_signature.rs
@@ -1,0 +1,121 @@
+use anyhow::{Context, Error, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct PcrSignatureConfigEntry {
+    /// Private key to sign the PCR policies
+    #[serde(alias = "privateKeyFile")]
+    pub private_key: PathBuf,
+    /// Boot phase paths separated by colons (e.g. `enter-initrd`, `enter-initrd:leave-initrd`) to sign a policy for.
+    /// If empty, defaults to default phases of `systemd-measure(1)`.
+    #[serde(default)]
+    pub phases: Vec<String>,
+    /// PCR Banks to sign a policy for.
+    /// If empty, defaults to default banks of `systemd-measure(1)`.
+    #[serde(default)]
+    pub banks: Vec<String>,
+}
+
+pub fn load_pcr_signature_config(
+    pcr_signature_config_path: &Path,
+) -> Result<Vec<PcrSignatureConfigEntry>> {
+    fs::read(pcr_signature_config_path)
+        .context("Failed to read PCR signature config file")
+        .and_then(|file| {
+            serde_json::from_slice(&file).context("Failed to deserialize PCR signature config")
+        })
+}
+
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct PcrPolicySignatureEntry {
+    pub pcrs: Vec<u8>,
+    pub pkfp: String,
+    pub pol: String,
+    pub sig: String,
+}
+
+type PcrPolicySignature = HashMap<String, Vec<PcrPolicySignatureEntry>>;
+
+/// Combine multiple PCR policy signatures into one (and remove duplicates)
+fn combine_pcr_policy_signatures(
+    policy_signatures: Vec<PcrPolicySignature>,
+) -> PcrPolicySignature {
+    let mut result = PcrPolicySignature::new();
+
+    for policy_signature in policy_signatures {
+        for (bank, measurement_objects) in policy_signature {
+            let result_measurement_objects = result.entry(bank).or_default();
+            for measurement_object in measurement_objects {
+                if !result_measurement_objects.contains(&measurement_object) {
+                    result_measurement_objects.push(measurement_object);
+                }
+            }
+        }
+    }
+    result
+}
+
+/// Create a PCR policy signature using `systemd-measure sign` from the PE section files and section data files
+pub fn create_pcr_signature(
+    kernel_cmdline_path: &Path,
+    kernel_path: &Path,
+    initrd_path: &Path,
+    os_release_path: &Path,
+    pcr_signature_config_path: &Path,
+) -> Result<Vec<u8>> {
+    let pcr_signature_config = load_pcr_signature_config(pcr_signature_config_path)?;
+
+    let mut pcr_policy_signatures = Vec::new();
+
+    for pcr_signature_config_entry in pcr_signature_config {
+        let mut args = vec![
+            OsString::from("sign"),
+            OsString::from("--json=short"),
+            OsString::from("--cmdline"),
+            kernel_cmdline_path.into(),
+            OsString::from("--linux"),
+            kernel_path.into(),
+            OsString::from("--initrd"),
+            initrd_path.into(),
+            OsString::from("--osrel"),
+            os_release_path.into(),
+            OsString::from("--private-key"),
+            pcr_signature_config_entry.private_key.into(),
+        ];
+
+        for phase in pcr_signature_config_entry.phases {
+            args.push(OsString::from("--phase"));
+            args.push(phase.into());
+        }
+
+        for bank in pcr_signature_config_entry.banks {
+            args.push(OsString::from("--bank"));
+            args.push(bank.into());
+        }
+
+        let command = Command::new("systemd-measure")
+            .args(args)
+            .output()
+            .context("Failed to run systemd-measure. Maybe, the binary is not in PATH")?;
+
+        pcr_policy_signatures.push(
+            serde_json::from_slice::<PcrPolicySignature>(&command.stdout)
+                .context("Failed to deserialize PCR policy signature created by systemd-measure")?,
+        );
+    }
+
+    if !pcr_policy_signatures.is_empty() {
+        let pcr_policy_signature = combine_pcr_policy_signatures(pcr_policy_signatures);
+        Ok(
+            serde_json::to_vec(&pcr_policy_signature)
+                .context("Failed to serialize PCR policy signature")?,
+        )
+    } else {
+        Err(anyhow::anyhow!("PCR signature config is empty"))
+    }
+}

--- a/rust/tool/shared/src/pe.rs
+++ b/rust/tool/shared/src/pe.rs
@@ -1,23 +1,25 @@
+use anyhow::{Context, Result};
+use goblin::pe::PE;
+use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-use anyhow::{Context, Result};
-use goblin::pe::PE;
-use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 
+use crate::pcr_signature::create_pcr_signature;
 use crate::utils::{SecureTempDirExt, file_hash, tmpname};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StubParameters {
+    pub systemd_store_path: PathBuf,
     pub lanzaboote_store_path: PathBuf,
     pub kernel_cmdline: Vec<String>,
     pub os_release_contents: Vec<u8>,
     pub kernel_store_path: PathBuf,
     pub initrd_store_path: PathBuf,
+    pub pcr_signature_config_path: Option<PathBuf>,
     /// Kernel path rooted at the ESP
     /// i.e. if you refer to /boot/efi/EFI/NixOS/kernel.efi
     /// this gets turned into \\EFI\\NixOS\\kernel.efi as a UTF-16 string
@@ -28,12 +30,15 @@ pub struct StubParameters {
 }
 
 impl StubParameters {
+    #![allow(clippy::too_many_arguments)]
     pub fn new(
+        systemd: &Path,
         lanzaboote_stub: &Path,
         kernel_path: &Path,
         initrd_path: &Path,
         kernel_target: &Path,
         initrd_target: &Path,
+        pcr_signature_config: Option<&Path>,
         esp: &Path,
     ) -> Result<Self> {
         // Resolve maximally those paths
@@ -41,6 +46,7 @@ impl StubParameters {
         // unit tests.
 
         Ok(Self {
+            systemd_store_path: systemd.to_path_buf(),
             lanzaboote_store_path: lanzaboote_stub.to_path_buf(),
             kernel_store_path: kernel_path.to_path_buf(),
             initrd_store_path: initrd_path.to_path_buf(),
@@ -48,6 +54,7 @@ impl StubParameters {
             initrd_path_at_esp: esp_relative_uefi_path(esp, initrd_target)?,
             kernel_cmdline: Vec::new(),
             os_release_contents: Vec::new(),
+            pcr_signature_config_path: pcr_signature_config.map(Path::to_path_buf),
         })
     }
 
@@ -112,8 +119,24 @@ pub fn lanzaboote_image(
     let kernel_path_offs = initrd_path_offs + file_size(&initrd_path_file)?;
     let initrd_hash_offs = kernel_path_offs + file_size(&kernel_path_file)?;
     let kernel_hash_offs = initrd_hash_offs + file_size(&initrd_hash_file)?;
+    let pcr_signature_offs = kernel_hash_offs + file_size(&kernel_hash_file)?;
 
-    let sections = vec![
+    let pcr_signature_section =
+        if let Some(pcr_signature_config_path) = &stub_parameters.pcr_signature_config_path {
+            let pcr_signature = create_pcr_signature(
+                &kernel_cmdline_file,
+                &stub_parameters.kernel_store_path,
+                &stub_parameters.initrd_store_path,
+                &os_release,
+                pcr_signature_config_path,
+            )?;
+            let pcr_signature_file = tempdir.write_secure_file(&pcr_signature)?;
+            Some(s(".pcrsig", pcr_signature_file, pcr_signature_offs))
+        } else {
+            None
+        };
+
+    let mut sections = vec![
         s(".osrel", os_release, os_release_offs),
         s(".cmdline", kernel_cmdline_file, kernel_cmdline_offs),
         s(".initrd", initrd_path_file, initrd_path_offs),
@@ -121,6 +144,10 @@ pub fn lanzaboote_image(
         s(".initrdh", initrd_hash_file, initrd_hash_offs),
         s(".linuxh", kernel_hash_file, kernel_hash_offs),
     ];
+
+    if let Some(section) = pcr_signature_section {
+        sections.push(section);
+    }
 
     let image_path = tempdir.path().join(tmpname());
     wrap_in_pe(

--- a/rust/tool/systemd/src/cli.rs
+++ b/rust/tool/systemd/src/cli.rs
@@ -68,6 +68,10 @@ struct InstallCommand {
     #[arg(long)]
     pcrlock_directory: Option<PathBuf>,
 
+    /// JSON configuration for PCR policy signatures
+    #[arg(long)]
+    pcr_signature_config: Option<PathBuf>,
+
     /// EFI system partition mountpoint (e.g. efiSysMountPoint)
     esp: PathBuf,
 
@@ -109,6 +113,7 @@ fn install(args: InstallCommand) -> Result<()> {
 
     let installer_builder = install::InstallerBuilder::new(
         lanzaboote_stub,
+        args.pcr_signature_config,
         Architecture::from_nixos_system(&args.system)?,
         args.systemd,
         args.systemd_boot_loader_config,

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -27,6 +27,7 @@ use lanzaboote_tool::utils::{SecureTempDirExt, file_hash};
 
 pub struct InstallerBuilder {
     lanzaboote_stub: PathBuf,
+    pcr_signature_config: Option<PathBuf>,
     arch: Architecture,
     systemd: PathBuf,
     systemd_boot_loader_config: PathBuf,
@@ -41,6 +42,7 @@ impl InstallerBuilder {
     #![allow(clippy::too_many_arguments)]
     pub fn new(
         lanzaboote_stub: impl AsRef<Path>,
+        pcr_signature_config: Option<PathBuf>,
         arch: Architecture,
         systemd: PathBuf,
         systemd_boot_loader_config: PathBuf,
@@ -52,6 +54,7 @@ impl InstallerBuilder {
     ) -> Self {
         Self {
             lanzaboote_stub: lanzaboote_stub.as_ref().to_path_buf(),
+            pcr_signature_config,
             arch,
             systemd,
             systemd_boot_loader_config,
@@ -77,6 +80,7 @@ impl InstallerBuilder {
             broken_gens: BTreeSet::new(),
             gc_roots,
             lanzaboote_stub: self.lanzaboote_stub,
+            pcr_signature_config: self.pcr_signature_config,
             systemd: self.systemd,
             systemd_boot_loader_config: self.systemd_boot_loader_config,
             signer,
@@ -94,6 +98,7 @@ pub struct Installer<S: Signer> {
     broken_gens: BTreeSet<u64>,
     gc_roots: Roots,
     lanzaboote_stub: PathBuf,
+    pcr_signature_config: Option<PathBuf>,
     systemd: PathBuf,
     systemd_boot_loader_config: PathBuf,
     signer: S,
@@ -297,11 +302,13 @@ impl<S: Signer> Installer<S> {
             assemble_kernel_cmdline(&bootspec.init, bootspec.kernel_params.clone());
 
         let parameters = pe::StubParameters::new(
+            &self.systemd,
             &self.lanzaboote_stub,
             &bootspec.kernel,
             &initrd_location,
             &kernel_target,
             &initrd_target,
+            self.pcr_signature_config.as_deref(),
             &self.esp_paths.esp,
         )?
         .with_cmdline(&kernel_cmdline)

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -1,5 +1,6 @@
 use crate::common::{boot_linux_unchecked, get_cmdline, get_secure_boot_status};
 use alloc::{string::String, vec::Vec};
+use linux_bootloader::cpio::pack_cpio_literal;
 use linux_bootloader::uefi_helpers::{ParsedPe, PeInMemory};
 use log::{error, warn};
 use sha2::{Digest, Sha256};
@@ -18,6 +19,9 @@ pub struct UkiComponents {
 
     /// The kernel command-line.
     pub cmdline: CString16,
+
+    /// Raw JSON data with signed PCR values
+    pub pcr_signature: Option<Vec<u8>>,
 }
 
 /// Extract a string, stored as UTF-8, from a PE section.
@@ -78,6 +82,7 @@ impl UkiComponents {
             kernel_data,
             initrd_data,
             cmdline,
+            pcr_signature: pe.section_data(".pcrsig"),
         })
     }
 }
@@ -97,11 +102,25 @@ fn check_hash(data: &[u8], expected_hash: Hash, name: &str) -> uefi::Result<()> 
 pub fn boot_linux(
     handle: Handle,
     components: UkiComponents,
-    dynamic_initrds: Vec<Vec<u8>>,
+    mut dynamic_initrds: Vec<Vec<u8>>,
 ) -> uefi::Result<()> {
     let cmdline = get_cmdline(&components.cmdline);
 
     let mut initrd_data = components.initrd_data;
+
+    if let Some(pcr_signature) = components.pcr_signature {
+        if let Ok(cpio) = pack_cpio_literal(
+            &pcr_signature,
+            uefi::fs::Path::new(cstr16!("tpm2-pcr-signature.json")),
+            ".extra",
+            555,
+            444,
+        ) {
+            dynamic_initrds.push(cpio.into_inner());
+        } else {
+            warn!("Failed to pack cpio from PCR signature data.")
+        }
+    }
 
     // Correctness: dynamic initrds are supposed to be validated by caller,
     // i.e. they are system extension images or credentials


### PR DESCRIPTION
Implements signing for precalculated PCR values using `systemd-measure sign` with multiple private keys, PCR banks, and systemd boot phase paths and loads the PCR signatures from the PE section `.pcrsig` into a dynamic initrd at `/.extra/tpm2-pcr-signature.json` (path expected by systemd's tools).

This should enable users to bind their LUKS decryption with TPM2 to PCR 11 without re-enrolling the keys on every update.

~~Depends on #546 and currently contains the commit of #546 for the NixOS test to pass.
(Feel free to close the other PR if you prefer to review/merge everything as one PR)~~

