### PR TITLE
[Docs] More familiar flakes example

### DIFF
--- a/docs/getting-started/prepare-your-system.md
+++ b/docs/getting-started/prepare-your-system.md
@@ -81,7 +81,7 @@ lanzaboote = import sources.lanzaboote { inherit pkgs; };
 
 ## Configure NixOS (with Flakes)
 
-**Step 1a**. Modify `flake.nix`: Add `lanzaboot` input
+**Step 1a**. Modify `flake.nix`: Add `lanzaboote` input
 
 ```nix
 inputs = {
@@ -96,7 +96,7 @@ inputs = {
 };
 ```
 
-**Step 1b**. Modify `flake.nix`: Add `lanzaboot` module to
+**Step 1b**. Modify `flake.nix`: Add `lanzaboote` module to
    `nixosConfigurations.<hostname>.modules` in `outputs`
 
 ```nix

--- a/docs/getting-started/prepare-your-system.md
+++ b/docs/getting-started/prepare-your-system.md
@@ -81,56 +81,67 @@ lanzaboote = import sources.lanzaboote { inherit pkgs; };
 
 ## Configure NixOS (with Flakes)
 
-Add this fragment to your `flake.nix`:
+**Step 1a**. Modify `flake.nix`: Add `lanzaboot` input
 
 ```nix
-{
-  description = "A SecureBoot-enabled NixOS configurations";
-
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
+inputs = {
+    ...
     lanzaboote = {
       url = "github:nix-community/lanzaboote/v1.0.0";
 
       # Optional but recommended to limit the size of your system closure.
       inputs.nixpkgs.follows = "nixpkgs";
     };
-  };
+    ...
+};
+```
 
-  outputs = { self, nixpkgs, lanzaboote, ...}: {
-    nixosConfigurations = {
-      yourHost = nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
+**Step 1b**. Modify `flake.nix`: Add `lanzaboot` module to
+   `nixosConfigurations.<hostname>.modules` in `outputs`
 
+```nix
+outputs = { self, nixpkgs, lanzaboote, ...}: {
+    nixosConfigurations.<hostname> = {
+      nixpkgs.lib.nixosSystem {
+        ...
         modules = [
-          # This is not a complete NixOS configuration and you need to reference
-          # your normal configuration here.
-
-          lanzaboote.nixosModules.lanzaboote
-
-          ({ pkgs, lib, ... }: {
-
-            environment.systemPackages = [
-              # For debugging and troubleshooting Secure Boot.
-              pkgs.sbctl
-            ];
-
-            # Lanzaboote currently replaces the systemd-boot module.
-            # This setting is usually set to true in configuration.nix
-            # generated at installation time. So we force it to false
-            # for now.
-            boot.loader.systemd-boot.enable = lib.mkForce false;
-
-            boot.lanzaboote = {
-              enable = true;
-              pkiBundle = "/var/lib/sbctl";
-            };
-          })
+          lanzaboote.nixosModules.lanzaboote  # Add
+          configuration.nix  # Example
+          hardware-configuration.nix  # Example
+          ...
         ];
+        ...
       };
+   };
+};
+```
+
+Replace `<hostname>` with your device's `hostname`.
+
+
+**Step 2**. Modify `configuration.nix`: Disable `systemd-boot` module and enable `lanzaboot`
+
+```nix
+{config, lib, pkgs, ...}: {
+  ...
+  environment.systemPackages = with pkgs; [
+    ...
+    # For debugging and troubleshooting Secure Boot
+    sbctl
+  ];
+  boot = {
+    # Lanzaboote currently replaces the systemd-boot module.
+    # This setting is usually set to true in configuration.nix
+    # generated at installation time. So we force it to false
+    # for now.
+    loader.systemd-boot.enable = lib.mkForce false;
+
+    lanzaboote = {
+      enable = true;
+      pkiBundle = "/var/lib/sbctl";
     };
   };
+  ...
 }
 ```
 


### PR DESCRIPTION
...in particular the example now resembles the structure created by `nixos-generate-config --flake` more closely.

Indeed, there, the structure is

```
$ sudo nixos-generate-config --flake
$ ls -l /etc
flake.nix
configuration.nix
hardware-configuration.nix
```

and appears to be very common outsie the `nixos-generate-config` context.