### PR TITLE
lzbt: fix stub matching regex in register_installed_generation

### DIFF
--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -314,8 +314,8 @@ impl<S: Signer> Installer<S> {
         // The second number is the amount of times the boot entry has been tried unsuccessfully.
         // See https://uapi-group.org/specifications/specs/boot_loader_specification/#boot-counting
         let pattern = format!(
-            r"{}(\+\d(-\d)?)?.efi",
-            stub_prefix(generation, &self.signer)?
+            r"^{}(\+\d+(-\d+)?)?\.efi$",
+            regex::escape(&stub_prefix(generation, &self.signer)?)
         );
         let regex =
             Regex::new(&pattern).context("Failed to construct regex to read stubs from ESP")?;


### PR DESCRIPTION

The regex used to locate already-installed stubs on the ESP had four
issues:

- `\d` only matched single-digit try counts, so stubs with
  `bootcounting-initial-tries >= 10` would not be recognised as
  already installed and would be needlessly reinstalled on every run.
- The dot before `efi` was unescaped, matching any character.
- The pattern was unanchored.
- The stub prefix was interpolated unescaped into the pattern,
  but specialisation names may contain regex metacharacters.
