### PR TITLE
lzbt: with boot assessment, preserve at least one known-good boot entry when applying configuration limit

### DIFF
--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -120,16 +120,37 @@ impl<S: Signer> Installer<S> {
 
         // A configuration limit of 0 means there is no limit.
         if self.configuration_limit > 0 {
-            // Only install the number of generations configured. Reverse the list to only take the
-            // latest generations and then, after taking them, reverse the list again so that the
-            // generations are installed from oldest to newest, i.e. from smallest to largest
-            // generation version.
-            links = links
-                .into_iter()
+            // Only install the number of generations configured.
+            let mut versions_to_keep: BTreeSet<u64> = links
+                .iter()
                 .rev()
                 .take(self.configuration_limit)
-                .rev()
-                .collect()
+                .map(|l| l.version)
+                .collect();
+
+            // When boot counting is enabled, ensure at least one known-good entry
+            // is preserved to avoid an ESP with only unassessed boot entries.
+            // We scan the ESP here because the known-good status (absence of boot
+            // counting suffix) is on-disk state set by systemd-boot, and we need
+            // this information before deciding which generations to keep.
+            if self.bootcounting_initial_tries > 0 {
+                let known_good = self.find_known_good_generation_versions()?;
+                if !known_good.is_empty()
+                    && !versions_to_keep.iter().any(|v| known_good.contains(v))
+                {
+                    if let Some(fallback) =
+                        links.iter().rev().find(|l| known_good.contains(&l.version))
+                    {
+                        log::info!(
+                            "Preserving known-good generation {} as a bootable fallback.",
+                            fallback.version
+                        );
+                        versions_to_keep.insert(fallback.version);
+                    }
+                }
+            }
+
+            links.retain(|l| versions_to_keep.contains(&l.version));
         };
         self.install_generations_from_links(&links)?;
 
@@ -516,6 +537,46 @@ impl<S: Signer> Installer<S> {
         })?;
 
         Ok(())
+    }
+
+    /// Find generation versions with known-good (assessed) boot entries on the ESP.
+    ///
+    /// Known-good entries are boot stubs without a boot counting suffix (`+N` or
+    /// `+N-M` immediately before `.efi`). These are entries that systemd-boot has
+    /// marked as successfully booted by removing the tries counter from the filename.
+    ///
+    /// Both main generation stubs and specialisation stubs are matched, but since
+    /// they share the same generation version number, duplicates are deduplicated.
+    fn find_known_good_generation_versions(&self) -> Result<BTreeSet<u64>> {
+        // Capture group 1: generation version
+        // Capture group 2: boot counting suffix (if present, entry is not yet known-good)
+        // See https://uapi-group.org/specifications/specs/boot_loader_specification/#boot-counting
+        let re = Regex::new(r"^nixos-generation-(\d+)-.*?(\+\d+(-\d+)?)?\.efi$")
+            .context("Failed to compile generation filename regex")?;
+
+        let entries = match fs::read_dir(&self.esp_paths.linux) {
+            Ok(entries) => entries,
+            Err(_) => return Ok(BTreeSet::new()),
+        };
+
+        let mut versions = BTreeSet::new();
+        for entry in entries {
+            let entry = entry?;
+            let Some(name) = entry.file_name().to_str().map(String::from) else {
+                continue;
+            };
+            if let Some(caps) = re.captures(&name) {
+                // Known-good entries have no boot counting suffix before .efi
+                if caps.get(2).is_some() {
+                    continue;
+                }
+                if let Ok(version) = caps[1].parse::<u64>() {
+                    versions.insert(version);
+                }
+            }
+        }
+
+        Ok(versions)
     }
 }
 

--- a/rust/tool/systemd/tests/integration/common.rs
+++ b/rust/tool/systemd/tests/integration/common.rs
@@ -168,6 +168,30 @@ pub fn lanzaboote_install(
     esp_mountpoint: &Path,
     generation_links: impl IntoIterator<Item = impl AsRef<OsStr>>,
 ) -> Result<Output> {
+    lanzaboote_install_impl(config_limit, 0, esp_mountpoint, generation_links)
+}
+
+/// Call the `lanzaboote install` command with boot counting enabled.
+pub fn lanzaboote_install_with_bootcounting(
+    config_limit: u64,
+    bootcounting_tries: u32,
+    esp_mountpoint: &Path,
+    generation_links: impl IntoIterator<Item = impl AsRef<OsStr>>,
+) -> Result<Output> {
+    lanzaboote_install_impl(
+        config_limit,
+        bootcounting_tries,
+        esp_mountpoint,
+        generation_links,
+    )
+}
+
+fn lanzaboote_install_impl(
+    config_limit: u64,
+    bootcounting_tries: u32,
+    esp_mountpoint: &Path,
+    generation_links: impl IntoIterator<Item = impl AsRef<OsStr>>,
+) -> Result<Output> {
     // To simplify the test setup, we use the systemd stub here instead of the lanzaboote stub. See
     // the comment in setup_toplevel for details.
     let architecture = Architecture::from_nixos_system(SYSTEM)?;
@@ -183,8 +207,7 @@ pub fn lanzaboote_install(
     fs::write(test_loader_config_path.path(), test_loader_config)?;
 
     let mut cmd = Command::new(cargo_bin!("lzbt-systemd"));
-    let output = cmd
-        .env("LANZABOOTE_STUB", test_systemd_stub)
+    cmd.env("LANZABOOTE_STUB", test_systemd_stub)
         .arg("-vv")
         .arg("install")
         .arg("--system")
@@ -199,9 +222,10 @@ pub fn lanzaboote_install(
         .arg("tests/fixtures/uefi-keys/db.key")
         .arg("--configuration-limit")
         .arg(config_limit.to_string())
-        .arg(esp_mountpoint)
-        .args(generation_links)
-        .output()?;
+        .arg("--bootcounting-initial-tries")
+        .arg(bootcounting_tries.to_string());
+
+    let output = cmd.arg(esp_mountpoint).args(generation_links).output()?;
 
     // Print debugging output.
     // This is a weird hack to make cargo test capture the output.

--- a/rust/tool/systemd/tests/integration/gc.rs
+++ b/rust/tool/systemd/tests/integration/gc.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use tempfile::tempdir;
@@ -119,6 +119,156 @@ fn keep_unrelated_files_on_esp() -> Result<()> {
     assert!(unrelated_uki.exists());
     assert!(unrelated_os.exists());
     assert!(unrelated_firmware.exists());
+
+    Ok(())
+}
+
+/// Check whether any stub for the given generation number exists in the linux directory.
+fn has_generation(linux_dir: &Path, version: u64) -> bool {
+    fs::read_dir(linux_dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .any(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|s| s.starts_with(&format!("nixos-generation-{version}-")))
+        })
+}
+
+/// Simulate a generation becoming known-good by removing the boot counting
+/// suffix from its stubs (as systemd-boot does after a successful boot).
+fn mark_generation_known_good(linux_dir: &Path, version: u64, tries: u32) -> Result<()> {
+    for entry in fs::read_dir(linux_dir)? {
+        let entry = entry?;
+        let name = entry.file_name().to_str().unwrap().to_string();
+        if name.starts_with(&format!("nixos-generation-{version}-"))
+            && name.contains(&format!("+{tries}"))
+        {
+            let new_name = name.replace(&format!("+{tries}"), "");
+            fs::rename(entry.path(), linux_dir.join(&new_name))?;
+        }
+    }
+    Ok(())
+}
+
+/// With boot counting enabled and a configuration limit, known-good entries
+/// can be pushed out by newer unassessed entries. The installer must preserve
+/// at least the most recent known-good generation as a bootable fallback.
+#[test]
+fn preserve_known_good_entry_with_boot_counting() -> Result<()> {
+    let esp_mountpoint = tempdir()?;
+    let tmpdir = tempdir()?;
+    let profiles = tempdir()?;
+    let generation_links: Vec<PathBuf> = (1..=5)
+        .map(|v| {
+            common::setup_generation_link(tmpdir.path(), profiles.path(), v)
+                .expect("Failed to setup generation link")
+        })
+        .collect();
+    let linux_dir = esp_mountpoint.path().join("EFI/Linux");
+
+    // Install all 5 generations with boot counting (tries=3).
+    let output = common::lanzaboote_install_with_bootcounting(
+        0,
+        3,
+        esp_mountpoint.path(),
+        generation_links.clone(),
+    )?;
+    assert!(output.status.success());
+
+    // Simulate generation 3 becoming known-good.
+    mark_generation_known_good(&linux_dir, 3, 3)?;
+
+    // Install with limit=2 and boot counting. Without the fix, generation 3
+    // would be garbage collected, leaving only unassessed entries 4 and 5.
+    let output = common::lanzaboote_install_with_bootcounting(
+        2,
+        3,
+        esp_mountpoint.path(),
+        generation_links,
+    )?;
+    assert!(output.status.success());
+
+    // Generation 3 (known-good fallback) and 4, 5 (latest 2) should be present.
+    assert!(
+        has_generation(&linux_dir, 3),
+        "Known-good generation 3 should be preserved"
+    );
+    assert!(
+        has_generation(&linux_dir, 4),
+        "Generation 4 should be present"
+    );
+    assert!(
+        has_generation(&linux_dir, 5),
+        "Generation 5 should be present"
+    );
+
+    // Older non-known-good generations should be garbage collected.
+    assert!(
+        !has_generation(&linux_dir, 1),
+        "Generation 1 should be garbage collected"
+    );
+    assert!(
+        !has_generation(&linux_dir, 2),
+        "Generation 2 should be garbage collected"
+    );
+
+    Ok(())
+}
+
+/// When a known-good generation is already within the configuration limit,
+/// no extra entry should be added.
+#[test]
+fn no_extra_entry_when_known_good_within_limit() -> Result<()> {
+    let esp_mountpoint = tempdir()?;
+    let tmpdir = tempdir()?;
+    let profiles = tempdir()?;
+    let generation_links: Vec<PathBuf> = (1..=3)
+        .map(|v| {
+            common::setup_generation_link(tmpdir.path(), profiles.path(), v)
+                .expect("Failed to setup generation link")
+        })
+        .collect();
+    let linux_dir = esp_mountpoint.path().join("EFI/Linux");
+    let stub_count = || count_files(&linux_dir).unwrap();
+
+    // Install all 3 generations with boot counting.
+    let output = common::lanzaboote_install_with_bootcounting(
+        0,
+        3,
+        esp_mountpoint.path(),
+        generation_links.clone(),
+    )?;
+    assert!(output.status.success());
+
+    // Mark generation 3 (the latest) as known-good.
+    mark_generation_known_good(&linux_dir, 3, 3)?;
+
+    // Install with limit=2 and boot counting.
+    // Generation 3 is already among the latest 2, so no extra entry is needed.
+    let output = common::lanzaboote_install_with_bootcounting(
+        2,
+        3,
+        esp_mountpoint.path(),
+        generation_links,
+    )?;
+    assert!(output.status.success());
+
+    // Exactly 2 generations should remain (4 stubs: 2 main + 2 specialisations).
+    assert_eq!(stub_count(), 4, "Should have exactly 2 generations");
+    assert!(
+        has_generation(&linux_dir, 2),
+        "Generation 2 should be present"
+    );
+    assert!(
+        has_generation(&linux_dir, 3),
+        "Generation 3 should be present"
+    );
+    assert!(
+        !has_generation(&linux_dir, 1),
+        "Generation 1 should be garbage collected"
+    );
 
     Ok(())
 }


### PR DESCRIPTION

With boot assessment enabled, applying the configuration limit can evict
all known-good entries from the ESP, leaving only unassessed entries
with boot counting suffixes. If all of those fail assessment, the system
can become unbootable.

Scan the ESP for stubs without a boot counting suffix (+N) before
selecting which generations to keep. If none of the latest N generations
(N = configuration_limit) are known-good, but known-good entries do exist,
then also include the most recent known-good generation as a fallback.
This means that we may exceed the configured limit by one entry.

