### PR TITLE
Measured Boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added support for Measured Boot via `systemd-pcrlock`. Refer to the [Measured
+  Boot
+  guide](https://nix-community.github.io/lanzaboote/how-to-guides/enable-measured-boot.html)
+  to get started using this.
+
 ## 1.0.0
 
 ### Added

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -12,6 +12,7 @@
 - [Automatically Generate Keys](how-to-guides/automatically-generate-keys.md)
 - [Automatically Enroll Keys](how-to-guides/automatically-enroll-keys.md)
 - [Disable Secure Boot](how-to-guides/disable-secure-boot.md)
+- [Enable Measured Boot](how-to-guides/enable-measured-boot.md)
 
 # Explanation
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,3 +20,4 @@
 - [Automatic Provisioning](explanation/automatic-provisioning.md)
 - [Windows Dual-Boot & Bitlocker](explanation/windows-dual-boot-bitlocker.md)
 - [Troubleshooting](explanation/troubleshooting.md)
+- [Measured Boot](explanation/measured-boot.md)

--- a/docs/explanation/measured-boot.md
+++ b/docs/explanation/measured-boot.md
@@ -1,0 +1,38 @@
+# Measured Boot
+
+Lanzaboote supports Measured Boot by creating a TPM2 policy via
+`systemd-pcrlock` that can be used to seal a secret (e.g. your LUKS2 key)
+inside a TPM to an expected state of your system.
+
+Most importantly, you can use this to improve the security of your LUKS2 volume
+encryption. It will only allow the unlocking of the volume if your system is in
+an expected state. You can use this fully unattended by only relying on the
+policy or in combination of a user provided pin.
+
+## Supported PCRs
+
+We believe that these are the most important and usable PCRs to achieve a
+secure system.
+
+- 0
+- 1
+- 2
+- 3
+- 4
+- 7
+
+See the
+[UAPI.7](https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/)
+spec for a full explanation of what is measured into each PCR.
+
+## Boot Loader and Lanzaboote Measurements
+
+The most important measurement for Lanzaboote is PCR 4. It covers the boot
+loader and the Lanzaboote stub. We leverage the same idea that we use for
+Secure Boot: only the stub needs to be covered because we check the hash of all
+other included components from the stub. We therefore cover the initrd, the
+kernel, and the cmdline which is included in the stub itself. Thus, by
+including PCR 4 in our policy we cover the entire boot chain after the firmware
+has booted.
+
+

--- a/docs/how-to-guides/enable-measured-boot.md
+++ b/docs/how-to-guides/enable-measured-boot.md
@@ -1,0 +1,81 @@
+# Enable Measured Boot
+
+This guide will walk you through enabling Measured Boot on a system that
+already has some form of `LUKS2` disk encryption and migrating this `LUKS2`
+volume to Measured Boot.
+
+> [!NOTE]
+> We do not support filesystem level encryption via ZFS or brtfs.
+>
+> While you will be able to use this same basic mechanism (i.e. a managed TPM2
+> policy) for unlocking filesystem level encryption, there is no integration we
+> provide for it. You will have to implement this yourself.
+
+## Enable Measured Boot in Your Config
+
+> [!NOTE]
+> If you enable Measured Boot, the maximum allowed `configurationLimit` is 8.
+> This limit is enforced by `systemd-pcrlock` [which currently won't create a
+> policy for more than 8
+> variants](https://github.com/systemd/systemd/issues/41526).
+
+```nix
+boot.lanzaboote = {
+  measuredBoot = {
+    enable = true;
+    pcrs = [
+      0
+      1
+      2
+      3
+      4
+      7
+    ];
+  };
+};
+```
+
+## Switch to the New Generation
+
+Switch to the new generation:
+
+```
+nixos-rebuild boot
+```
+
+> [!NOTE]
+> If you're using an ephemeral root, you need to persist
+> `boot.lanzaboote.measuredBoot.pcrlockPolicy` and
+> `boot.lanzaboote.measuredBoot.pcrlockDirectory` across reboots.
+
+Now reboot:
+
+```
+reboot
+```
+
+## Enroll the Policy
+
+> [!CAUTION]
+> Always enroll some form of recovery key or passphrase!
+>
+> `systemd-pcrlock` is still considered experimental by systemd. So to avoid
+> data loss in the case of misconfiguration or other TPM issues, you should
+> have some way to manually unlock your volume.
+
+For an attended system like a workstation, you should enforce some kind of user
+secret *in addition* to the TPM for unlocking your encrypted (root) volume.
+Thus, use the option `--tpm2-with-pin=true` for systemd-cryptenroll.
+
+```
+systemd-cryptenroll \
+  --tpm2-device=auto \
+  --tpm2-with-pin=true \
+  --tpm2-pcrlock=/var/lib/systemd/pcrlock.json \
+  /dev/sdX
+```
+
+Congratulations, you are now a proud user of Measured Boot! You will not need
+to re-enroll anything into your LUKS2 volume. Lanzaboote will automatically
+take care of creating measurements and updating the TPM policy whenever you
+update your system via `nixos-rebuild`.

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -22,19 +22,62 @@ let
   ]
   ++ cfg.extraEfiSysMountPoints;
 
-  mkInstallCommand = efiSysMountPoint: ''
-    ${cfg.installCommand} \
-      --public-key ${cfg.publicKeyFile} \
-      --private-key ${cfg.privateKeyFile} \
-      ${efiSysMountPoint} \
-      /nix/var/nix/profiles/system-*-link
-  '';
+  mkInstallCommand =
+    efiSysMountPoint:
+    ''
+      PATH=${config.systemd.package}/lib/systemd:$PATH
+      ${cfg.installCommand} \
+    ''
+    + (
+      lib.escapeShellArgs (
+        [
+          "--public-key=${toString cfg.publicKeyFile}"
+          "--private-key=${toString cfg.privateKeyFile}"
+        ]
+        ++ lib.optionals (cfg.measuredBoot.enable && pcr 4) [
+          "--pcrlock-directory=${cfg.measuredBoot.pcrlockDirectory}"
+        ]
+        ++ [
+          efiSysMountPoint
+        ]
+      )
+      + " /nix/var/nix/profiles/system-*-link"
+    );
 
   format = pkgs.formats.yaml { };
   sbctlConfigFile = format.generate "sbctl.conf" {
     keydir = "${cfg.pkiBundle}/keys";
     guid = "${cfg.pkiBundle}/GUID";
   };
+
+  json = pkgs.formats.json { };
+
+  pcr = n: lib.elem n cfg.measuredBoot.pcrs;
+
+  staticMeasurements = pkgs.runCommand "pcrlock.d" { preferLocalBuild = true; } ''
+    mkdir -p $out
+
+    for f in ${toString cfg.measuredBoot.upstreamStaticMeasurements}; do
+      mkdir -p $(dirname $out/$f)
+      ln -sf ${config.systemd.package}/lib/pcrlock.d/$f $out/$f
+    done
+
+    ${lib.concatLines (
+      lib.mapAttrsToList (n: v: "ln -s ${v.source} $out/${n}.pcrlock") cfg.measuredBoot.staticMeasurements
+    )}
+  '';
+
+  makePolicyCommand = lib.escapeShellArgs (
+    [
+      "${config.systemd.package}/lib/systemd/systemd-pcrlock"
+      "make-policy"
+      "--components=${staticMeasurements}"
+      "--components=${cfg.measuredBoot.pcrlockDirectory}"
+      "--policy=${cfg.measuredBoot.pcrlockPolicy}"
+      "--location=770"
+    ]
+    ++ lib.map (pcr: "--pcr=${toString pcr}") cfg.measuredBoot.pcrs
+  );
 in
 {
   imports = [
@@ -248,6 +291,114 @@ in
         '';
       };
     };
+
+    measuredBoot = {
+      enable = lib.mkEnableOption "Measured Boot";
+
+      pcrs = lib.mkOption {
+        type = lib.types.listOf (
+          lib.types.enum [
+            0
+            1
+            2
+            3
+            4
+            7
+          ]
+        );
+        default = [ ];
+        description = ''
+          PCRs to lock via systemd-pcrlock.
+        '';
+      };
+
+      pcrlockDirectory = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/pcrlock.d";
+        description = ''
+          Directory to store the pcrlock files in.
+        '';
+      };
+
+      pcrlockPolicy = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/systemd/pcrlock.json";
+        description = ''
+          Location to store the pcrlock policy in.
+        '';
+      };
+
+      upstreamStaticMeasurements = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = ''
+          Filenames of static pcrlock measurements to include from the systemd
+          package.
+        '';
+      };
+
+      staticMeasurements = lib.mkOption {
+        default = { };
+        description = ''
+          Static systemd-pcrlock measurements.
+        '';
+        type = lib.types.attrsOf (
+          lib.types.submodule (
+            {
+              name,
+              config,
+              options,
+              ...
+            }:
+            {
+              options = {
+                source = lib.mkOption {
+                  type = lib.types.path;
+                  description = "Path of the source file.";
+                };
+                json = lib.mkOption {
+                  default = null;
+                  type = lib.types.nullOr json.type;
+                  description = ''
+                    systemd-pcrlock components in their literal form. This option is directly transformed to a JSON.
+                  '';
+                };
+              };
+              config = {
+                source = lib.mkIf (config.json != null) (
+                  lib.mkDerivedConfig options.json (json.generate "${name}.pcrlock")
+                );
+              };
+            }
+          )
+        );
+      };
+
+      autoCryptenroll = {
+        enable = lib.mkEnableOption "automatically re-enroll systemd-pcrlock TPM2 policy into LUKS volume";
+
+        device = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            The device that is encrypted via LUKS2 to enroll the TPM2 policy into.
+
+            This is useful for unattended systems to upgrade a LUKS2 volume
+            from being locked against a static PCR to a full systemd-pcrlock
+            policy.
+          '';
+        };
+
+        autoReboot = lib.mkEnableOption "" // {
+          description = ''
+            Whether to automatically reboot after preparing the measurements.
+
+            Enable this to enroll the new systemd-pcrlock policy with full
+            protection without having to wait for a manual reboot.
+          '';
+        };
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -262,6 +413,16 @@ in
             2. Accept the risk via autoEnrollKeys.allowBrickingMyMachine
         '';
       }
+      {
+        assertion = cfg.measuredBoot.enable -> (configurationLimit > 0 && configurationLimit <= 8);
+        message = ''
+          If Measured Boot is enabled, you cannot store more than 8 generations on the ESP.
+
+            This is a strict limit required and enforced by systemd-pcrlock.
+
+            Set `boot.lanzaboote.configurationLimit = 8;` to reduce the number of generations you store.
+        '';
+      }
     ];
 
     boot.bootspec = {
@@ -274,15 +435,67 @@ in
     boot.loader.external = {
       enable = true;
       installHook = pkgs.writeShellScript "bootinstall" (
-        lib.concatStringsSep "\n" (map mkInstallCommand efiSysMountPoints)
+        ''
+          ${lib.concatStringsSep "\n" (map mkInstallCommand efiSysMountPoints)}
+        ''
+        + lib.optionalString cfg.measuredBoot.enable ''
+          echo "Predicting the PCR state for future boots..."
+          ${makePolicyCommand}
+        ''
       );
     };
+    boot.lanzaboote.measuredBoot.upstreamStaticMeasurements =
+      lib.optionals (pcr 0 || pcr 1 || pcr 2 || pcr 3 || pcr 4) [
+        "500-separator.pcrlock.d/300-0x00000000.pcrlock"
+      ]
+      ++ lib.optionals (pcr 4) [
+        "350-action-efi-application.pcrlock"
+      ]
+      ++ lib.optionals (pcr 7) [
+        "400-secureboot-separator.pcrlock.d/300-0x00000000.pcrlock"
+      ];
 
     environment.etc."sbctl/sbctl.conf" =
       lib.mkIf (cfg.autoGenerateKeys.enable || cfg.autoEnrollKeys.enable)
         {
           source = sbctlConfigFile;
         };
+
+    # Write this to /etc so that manually calling systemd-pcrlock by the user
+    # still works without them having to specify the directory.
+    environment.etc."pcrlock" = lib.mkIf cfg.measuredBoot.enable {
+      target = "pcrlock.d";
+      source = staticMeasurements;
+    };
+
+    systemd.additionalUpstreamSystemUnits = lib.mkIf cfg.measuredBoot.enable [
+      "systemd-pcrlock-make-policy.service"
+      "systemd-pcrlock-firmware-code.service"
+      "systemd-pcrlock-firmware-config.service"
+      "systemd-pcrlock-secureboot-policy.service"
+      "systemd-pcrlock-secureboot-authority.service"
+    ];
+    systemd.services.systemd-pcrlock-make-policy = lib.mkIf cfg.measuredBoot.enable {
+      wantedBy = [ "sysinit.target" ];
+
+      serviceConfig.ExecStart = [
+        "" # unset previous value
+        makePolicyCommand
+      ];
+    };
+    systemd.targets.sysinit = lib.mkIf cfg.measuredBoot.enable {
+      wants =
+        lib.optionals (pcr 0 || pcr 2) [
+          "systemd-pcrlock-firmware-code.service"
+        ]
+        ++ lib.optionals (pcr 1 || pcr 3) [
+          "systemd-pcrlock-firmware-config.service"
+        ]
+        ++ lib.optionals (pcr 7) [
+          "systemd-pcrlock-secureboot-policy.service"
+          "systemd-pcrlock-secureboot-authority.service"
+        ];
+    };
 
     systemd.services.generate-sb-keys = lib.mkIf cfg.autoGenerateKeys.enable {
       wantedBy = [ "multi-user.target" ];
@@ -316,13 +529,11 @@ in
           "!${espMountPoint}/loader/keys/auto/KEK.auth"
           "!${espMountPoint}/loader/keys/auto/db.auth"
         ];
-        SuccessAction = lib.mkIf cfg.autoEnrollKeys.autoReboot "reboot";
       };
 
       serviceConfig = {
         Type = "oneshot";
-        # SuccessAction doesn't trigger if the service is RemainAfterExit
-        RemainAfterExit = lib.mkIf (!cfg.autoEnrollKeys.autoReboot) true;
+        RemainAfterExit = true;
         RuntimeDirectory = "prepare-sb-auto-enroll";
         WorkingDirectory = "/run/prepare-sb-auto-enroll";
       };
@@ -349,6 +560,88 @@ in
           ${mkInstallCommand espMountPoint}
         '';
     };
+
+    # Re-create/sign all artifacts on the ESP to securely generate pcrlock
+    # measurements. If this is successful, immediately reboot. Only on the next
+    # boot can the new policy be created and enrolled because the artifacts
+    # which were used for the current boot might not be the ones used after
+    # re-creating/signing them. systemd-pcrlock only allows including PCRs if
+    # the current TPM measurements are included.
+    systemd.services.prepare-auto-cryptenroll = lib.mkIf cfg.measuredBoot.autoCryptenroll.enable {
+      wantedBy = [ "sysinit.target" ];
+      before = [ "systemd-pcrlock-make-policy.service" ];
+      # Allow creating files for re-creating/signing via systemd-tmpfiles.
+      # This is useful for testing and shouldn't harm anything.
+      after = [ "systemd-tmpfiles-setup.service" ];
+
+      unitConfig = {
+        DefaultDependencies = false;
+        # Only run once before any policy was created because this only needs
+        # to be done once when enabling Measured Boot for the first time. On
+        # subsequent boots, this is handled via lzbt in the bootinstall hook of
+        # switch-to-configuration.
+        ConditionPathExists = [ "!${cfg.measuredBoot.pcrlockPolicy}" ];
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+
+      script = ''
+        ${mkInstallCommand espMountPoint}
+      '';
+    };
+
+    systemd.services.auto-cryptenroll = lib.mkIf cfg.measuredBoot.autoCryptenroll.enable {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "prepare-auto-cryptenroll.service" ];
+
+      unitConfig = {
+        ConditionPathExists = [
+          "${cfg.measuredBoot.pcrlockPolicy}"
+          # If this path exists the new policy was already enrolled and thus
+          # does not need to be enrolled again. systemd-pcrlock will update the
+          # policy in place in the same NV index of the TPM.
+          "!/var/lib/auto-cryptenroll/1"
+        ];
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        StateDirectory = "auto-cryptenroll";
+        ExecStart = ''
+          systemd-cryptenroll \
+            --wipe-slot=tpm2 \
+            --tpm2-device=auto \
+            --unlock-tpm2-device=auto \
+            --tpm2-pcrlock=${cfg.measuredBoot.pcrlockPolicy} \
+            ${cfg.measuredBoot.autoCryptenroll.device}
+        '';
+        ExecStartPost = "${pkgs.coreutils}/bin/touch /var/lib/auto-cryptenroll/1";
+      };
+    };
+
+    # Reboot in a separate service instead of via SuccessAction= in individual
+    # services so that users can both autoEnrollKeys and autoCryptenroll.
+    systemd.services.auto-reboot =
+      lib.mkIf (cfg.autoEnrollKeys.autoReboot || cfg.measuredBoot.autoCryptenroll.autoReboot)
+        {
+          requiredBy = [
+            "prepare-sb-auto-enroll.service"
+            "prepare-auto-cryptenroll.service"
+          ];
+          after = [
+            "prepare-sb-auto-enroll.service"
+            "prepare-auto-cryptenroll.service"
+          ];
+
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "systemctl reboot";
+          };
+        };
 
     systemd.services.fwupd = lib.mkIf config.services.fwupd.enable {
       # Tell fwupd to load its efi files from /run

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -153,6 +153,17 @@ in
       };
     };
 
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "info"
+        "debug"
+      ];
+      default = "info";
+      description = ''
+        Log level of lzbt.
+      '';
+    };
+
     installCommand = lib.mkOption {
       type = lib.types.str;
       readOnly = true;
@@ -164,7 +175,7 @@ in
       default = ''
         # Use the system from the kernel's hostPlatform because this should
         # always, even in the cross compilation case, be the right system.
-        ${lib.getExe cfg.package} install \
+        ${lib.getExe cfg.package} ${lib.optionalString (cfg.logLevel == "debug") "-vv"} install \
           --system ${config.boot.kernelPackages.stdenv.hostPlatform.system} \
           --systemd ${config.systemd.package} \
           --systemd-boot-loader-config ${loaderConfigFile} \
@@ -172,7 +183,7 @@ in
           --allow-unsigned ${lib.boolToString cfg.allowUnsigned} \
           --bootcounting-initial-tries ${toString cfg.bootCounting.initialTries}'';
       defaultText = lib.literalExpression ''
-        ''${lib.getExe config.boot.lanzaboote.package} install \
+        ''${lib.getExe config.boot.lanzaboote.package} ''${lib.optionalString (config.boot.lanzaboote.logLevel == "debug") "-vv"} install \
           --system ''${config.boot.kernelPackages.stdenv.hostPlatform.system} \
           --systemd ''${config.systemd.package} \
           --systemd-boot-loader-config ''${loaderConfigFile} \

--- a/nix/packages/lzbt.nix
+++ b/nix/packages/lzbt.nix
@@ -39,7 +39,7 @@ buildRustApp {
       in
       ''
         makeWrapper $out/bin/lzbt-systemd $out/bin/lzbt \
-          --set PATH ${path} \
+          --prefix PATH : ${path} \
           --set LANZABOOTE_STUB ${stub}/bin/lanzaboote_stub.efi
       '';
 

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -27,6 +27,7 @@ in
   extra-efi-partitions = runTest ./lanzaboote/extra-efi-partitions.nix;
   auto-generate-enroll = runTest ./lanzaboote/auto-generate-enroll.nix;
   boot-counting = runTest ./lanzaboote/boot-counting.nix;
+  measured-boot = runTest ./lanzaboote/measured-boot.nix;
 
   systemd-pcrlock = runTest ./lanzaboote/systemd-pcrlock.nix;
   systemd-measure = runTest ./lanzaboote/systemd-measure.nix;

--- a/nix/tests/lanzaboote/common/lanzaboote.nix
+++ b/nix/tests/lanzaboote/common/lanzaboote.nix
@@ -27,6 +27,7 @@ in
 
       lanzaboote = {
         enable = true;
+        logLevel = "debug";
         pkiBundle = lib.mkDefault pkiBundle;
       };
     };

--- a/nix/tests/lanzaboote/measured-boot.nix
+++ b/nix/tests/lanzaboote/measured-boot.nix
@@ -1,0 +1,173 @@
+{
+  name = "lanzaboote-measured-boot";
+
+  nodes.machine =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      imports = [ ./common/lanzaboote.nix ];
+
+      virtualisation.tpm.enable = true;
+
+      lanzabooteTest = {
+        persistentRoot = true;
+      };
+
+      boot.lanzaboote = {
+        configurationLimit = 8;
+        measuredBoot = {
+          enable = true;
+          pcrs = [
+            0
+            1
+            2
+            3
+            4
+            7
+          ];
+          autoCryptenroll = {
+            enable = true;
+            device = config.boot.initrd.luks.devices."encrypted".device;
+          };
+        };
+      };
+
+      boot.initrd = {
+        luks.devices = {
+          encrypted.device = "/dev/disk/by-partlabel/encrypted";
+        };
+
+        systemd = {
+          enable = true;
+          repart = {
+            enable = true;
+          };
+        };
+      };
+
+      image.repart.partitions = {
+        # Use a fix type to accurately match against it with repart during
+        # runtime.
+        "nix-store".repartConfig.Type = lib.mkForce "9141b5b5-1a5c-4867-89f6-d3ebab0ef668";
+        # Leave some padding at the end of the root partition so we have enough
+        # space to create a encrypted partition.
+        "root".repartConfig.PaddingMinBytes = "100M";
+      };
+      systemd.repart.partitions = {
+        "nix-store" = {
+          Type = "9141b5b5-1a5c-4867-89f6-d3ebab0ef668";
+        };
+        "root" = {
+          Type = "root";
+        };
+        "encrypted" = {
+          Type = "linux-generic";
+          Label = "encrypted";
+          Format = "ext4";
+          Encrypt = "tpm2";
+          SizeMaxBytes = "10M";
+        };
+      };
+
+      fileSystems = {
+        "/encrypted" = {
+          device = "/dev/mapper/encrypted";
+          fsType = config.systemd.repart.partitions."encrypted".Format;
+        };
+      };
+
+      environment.systemPackages = [
+        pkgs.tree
+        pkgs.jq
+      ];
+
+      specialisation."new-generation".configuration = {
+        environment.systemPackages = [ pkgs.efibootmgr ];
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    (import ./common/image-helper.nix { inherit (nodes) machine; })
+    + (import ./common/efivariables-helper.nix)
+    + ''
+      import json
+
+      machine.start()
+
+      with subtest("TPM2 is setup"):
+        machine.wait_for_unit("systemd-tpm2-setup.service")
+
+      with subtest("vendor pcrlock components are present in /etc"):
+        print(machine.succeed("tree /etc/pcrlock.d"))
+
+      with subtest("pcrlock measurements are generated"):
+        machine.wait_for_unit("systemd-pcrlock-firmware-code.service")
+        machine.wait_for_unit("systemd-pcrlock-secureboot-authority.service")
+        machine.wait_for_unit("systemd-pcrlock-secureboot-policy.service")
+
+        with subtest("ESP artifact measurements are generated"):
+          machine.wait_for_unit("prepare-auto-cryptenroll.service")
+          print(machine.succeed("tree /var/lib/pcrlock.d"))
+          print(machine.succeed("stat /var/lib/pcrlock.d/630-bootloader.pcrlock.d/current.pcrlock"))
+          print(machine.succeed("stat /var/lib/pcrlock.d/635-lanzaboote.pcrlock.d/1.pcrlock"))
+          print(machine.succeed("stat /var/lib/pcrlock.d/635-lanzaboote.pcrlock.d/1-new-generation.pcrlock"))
+
+      with subtest("pcrlock policy is generated"):
+        machine.wait_for_unit("systemd-pcrlock-make-policy.service")
+        policy_json = machine.succeed("cat /var/lib/systemd/pcrlock.json | tee /dev/stderr")
+
+        with subtest("pcrlock policy contains static PCRs"):
+          policy = json.loads(policy_json)
+          pcrs = [x.get("pcr") for x in policy.get("pcrValues")]
+          t.assertIn(0, pcrs)
+          t.assertIn(1, pcrs)
+          t.assertIn(2, pcrs)
+          t.assertIn(3, pcrs)
+          t.assertIn(7, pcrs)
+
+        with subtest("pcrlock policy doesn't contain dynamic PCRs yet"):
+          # Doesn't contain PCR 4 yet because the currently booted Lanzaboote
+          # image was not measured. Only after a reboot will we boot the correct
+          # Lanzaboote image.
+          t.assertNotIn(4, pcrs)
+
+      with subtest("Encrypted partition is available and mounted"):
+        print(machine.succeed("findmnt /encrypted"))
+        print(machine.succeed("dmsetup info /dev/mapper/encrypted"))
+
+      with subtest("New policy is automatically enrolled"):
+        machine.wait_for_unit("auto-cryptenroll.service")
+        metadata_json = machine.succeed("cryptsetup luksDump /dev/disk/by-partlabel/encrypted --dump-json-metadata | tee /dev/stderr")
+        metadata = json.loads(metadata_json)
+
+        with subtest("Slot 0 was wiped after it was initially populated by systemd-repart"):
+          t.assertFalse(metadata.get("tokens").get("0"))
+        with subtest("Slot 1 is populated with pcrlock policy"):
+          t.assertTrue(metadata.get("tokens").get("1").get("tpm2_pcrlock"))
+
+      with subtest("systemd-pcrlock log works"):
+        print(machine.succeed("/run/current-system/systemd/lib/systemd/systemd-pcrlock log"))
+
+      # This will only work if all the generations are re-generated (and thus
+      # re-measured) and a new policy is enrolled via systemd-pcrlock.
+      with subtest("Reboot the system"):
+        machine.reboot()
+
+      with subtest("pcrlock policy contains all the PCRs"):
+        machine.wait_for_unit("systemd-pcrlock-make-policy.service")
+        policy_json = machine.succeed("cat /var/lib/systemd/pcrlock.json | tee /dev/stderr")
+        policy = json.loads(policy_json)
+        pcrs = [x.get("pcr") for x in policy.get("pcrValues")]
+        t.assertIn(0, pcrs)
+        t.assertIn(1, pcrs)
+        t.assertIn(2, pcrs)
+        t.assertIn(3, pcrs)
+        t.assertIn(4, pcrs)
+        t.assertIn(7, pcrs)
+    '';
+}

--- a/rust/tool/systemd/src/cli.rs
+++ b/rust/tool/systemd/src/cli.rs
@@ -65,6 +65,9 @@ struct InstallCommand {
     #[arg(long, default_value_t = 0)]
     bootcounting_initial_tries: u32,
 
+    #[arg(long)]
+    pcrlock_directory: Option<PathBuf>,
+
     /// EFI system partition mountpoint (e.g. efiSysMountPoint)
     esp: PathBuf,
 
@@ -111,6 +114,7 @@ fn install(args: InstallCommand) -> Result<()> {
         args.systemd_boot_loader_config,
         args.configuration_limit,
         args.bootcounting_initial_tries,
+        args.pcrlock_directory,
         args.esp,
         args.generations,
     );

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -14,6 +14,7 @@ use tempfile::TempDir;
 
 use crate::architecture::SystemdArchitectureExt;
 use crate::esp::SystemdEspPaths;
+use crate::pcrlock::{PcrlockPaths, lock_pe};
 use crate::version::SystemdVersion;
 use lanzaboote_tool::architecture::Architecture;
 use lanzaboote_tool::esp::EspPaths;
@@ -31,6 +32,7 @@ pub struct InstallerBuilder {
     systemd_boot_loader_config: PathBuf,
     configuration_limit: usize,
     bootcounting_initial_tries: u32,
+    pcrlock_directory: Option<PathBuf>,
     esp: PathBuf,
     generation_links: Vec<PathBuf>,
 }
@@ -44,6 +46,7 @@ impl InstallerBuilder {
         systemd_boot_loader_config: PathBuf,
         configuration_limit: usize,
         bootcounting_initial_tries: u32,
+        pcrlock_directory: Option<PathBuf>,
         esp: PathBuf,
         generation_links: Vec<PathBuf>,
     ) -> Self {
@@ -54,6 +57,7 @@ impl InstallerBuilder {
             systemd_boot_loader_config,
             configuration_limit,
             bootcounting_initial_tries,
+            pcrlock_directory,
             esp,
             generation_links,
         }
@@ -64,6 +68,11 @@ impl InstallerBuilder {
         let esp_paths = SystemdEspPaths::new(self.esp, self.arch);
         gc_roots.extend(esp_paths.iter());
 
+        let pcrlock_paths = self.pcrlock_directory.map(PcrlockPaths::new);
+        if let Some(pcrlock_paths) = &pcrlock_paths {
+            gc_roots.extend(pcrlock_paths.iter());
+        };
+
         Installer {
             broken_gens: BTreeSet::new(),
             gc_roots,
@@ -73,6 +82,7 @@ impl InstallerBuilder {
             signer,
             configuration_limit: self.configuration_limit,
             bootcounting_initial_tries: self.bootcounting_initial_tries,
+            pcrlock_paths,
             esp_paths,
             generation_links: self.generation_links,
             arch: self.arch,
@@ -89,6 +99,7 @@ pub struct Installer<S: Signer> {
     signer: S,
     configuration_limit: usize,
     bootcounting_initial_tries: u32,
+    pcrlock_paths: Option<PcrlockPaths>,
     esp_paths: SystemdEspPaths,
     generation_links: Vec<PathBuf>,
     arch: Architecture,
@@ -126,10 +137,10 @@ impl<S: Signer> Installer<S> {
 
         if self.broken_gens.is_empty() {
             log::info!("Collecting garbage...");
-            // Only collect garbage in these two directories. This way, no files that do not belong to
-            // the NixOS installation are deleted. Lanzatool takes full control over the esp/EFI/nixos
-            // directory and deletes ALL files that it doesn't know about. Dual- or multiboot setups
-            // that need files in this directory will NOT work.
+            // Only collect garbage in these two directories on the ESP. This way, no files that do
+            // not belong to the NixOS installation are deleted. Lanzatool takes full control over
+            // the esp/EFI/nixos directory and deletes ALL files that it doesn't know about. Dual-
+            // or multiboot setups that need files in this directory will NOT work.
             self.gc_roots.collect_garbage(&self.esp_paths.nixos)?;
             // The esp/EFI/Linux directory is assumed to be potentially shared with other distros.
             // Thus, only files that start with "nixos-" are garbage collected (i.e. potentially
@@ -140,6 +151,12 @@ impl<S: Signer> Installer<S> {
                         .and_then(|n| n.to_str())
                         .is_some_and(|n| n.starts_with("nixos-"))
                 })?;
+            // Only collect garbage in the Lanzaboote directory because that's the only directory
+            // we fully control. Bootloader measurements are not garbage collected because there is
+            // only a single installed bootloader version without the possibility of rollbacks.
+            if let Some(pcrlock_paths) = &self.pcrlock_paths {
+                self.gc_roots.collect_garbage(pcrlock_paths.lanzaboote())?;
+            }
         } else {
             // This might produce a ridiculous message if you have a lot of malformed generations.
             let warning = indoc::formatdoc! {"
@@ -213,6 +230,8 @@ impl<S: Signer> Installer<S> {
     /// Hence, this function cannot overwrite files of other generations with different contents.
     /// All installed files are added as garbage collector roots.
     fn install_generation(&mut self, generation: &Generation) -> Result<()> {
+        log::debug!("Installing generation {}", generation.version_tag());
+
         // If the generation is already properly installed, don't overwrite it.
         if self.register_installed_generation(generation)? {
             return Ok(());
@@ -291,6 +310,14 @@ impl<S: Signer> Installer<S> {
         let lanzaboote_image_path = lanzaboote_image(&tempdir, &parameters)
             .context("Failed to build and sign lanzaboote stub image.")?;
 
+        if let Some(pcrlock_paths) = &self.pcrlock_paths {
+            let lanzaboote_image_pcrlock =
+                pcrlock_paths.lanzaboote_measurement(generation.version_tag());
+            lock_pe(&lanzaboote_image_path, &lanzaboote_image_pcrlock)
+                .context("Failed to lock Lanzaboote image with systemd-pcrlock")?;
+            self.gc_roots.extend([&lanzaboote_image_pcrlock]);
+        }
+
         let stub_target = self.esp_paths.linux.join(
             stub_name(generation, &self.signer, self.bootcounting_initial_tries)
                 .context("Get stub name")?,
@@ -325,10 +352,22 @@ impl<S: Signer> Installer<S> {
         if let Ok((stub_target, kernel_path, initrd_path)) = self.read_installed_generation(regex) {
             self.gc_roots
                 .extend([&stub_target, &kernel_path, &initrd_path]);
-            Ok(true)
+            // Do not return yet, we still need to check the existence of the pcrlock measurements.
         } else {
-            Ok(false)
+            return Ok(false);
         }
+
+        if let Some(pcrlock_paths) = &self.pcrlock_paths {
+            let lanzaboote_image_pcrlock =
+                pcrlock_paths.lanzaboote_measurement(generation.version_tag());
+            if lanzaboote_image_pcrlock.exists() {
+                self.gc_roots.extend([&lanzaboote_image_pcrlock]);
+            } else {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
     }
 
     // Read the stub, kernel and initrd paths belonging to the generation matching the given regex.
@@ -401,24 +440,65 @@ impl<S: Signer> Installer<S> {
             .join("lib/systemd/boot/efi")
             .join(self.arch.systemd_filename());
 
-        let paths = [
-            (&systemd_boot, &self.esp_paths.efi_fallback),
-            (&systemd_boot, &self.esp_paths.systemd_boot),
-        ];
+        let newer_systemd_boot_available =
+            newer_systemd_boot(&systemd_boot, &self.esp_paths.efi_fallback)?
+                || newer_systemd_boot(&systemd_boot, &self.esp_paths.systemd_boot)?;
+        if newer_systemd_boot_available {
+            log::info!("Updating systemd-boot...")
+        };
 
-        for (from, to) in paths {
-            let newer_systemd_boot_available = newer_systemd_boot(from, to)?;
-            if newer_systemd_boot_available {
-                log::info!("Updating {to:?}...")
-            };
-            let systemd_boot_is_signed = &self.signer.verify_path(to)?;
-            if !systemd_boot_is_signed {
-                log::warn!("{to:?} is not signed. Replacing it with a signed binary...")
-            };
+        let systemd_boot_is_signed = self.signer.verify_path(&self.esp_paths.efi_fallback)?
+            && self.signer.verify_path(&self.esp_paths.systemd_boot)?;
+        if !systemd_boot_is_signed {
+            log::warn!("systemd-boot is not signed. Replacing it with a signed binary...")
+        };
 
-            if newer_systemd_boot_available || !systemd_boot_is_signed {
-                install_signed(&self.signer, from, to)
+        let measurement_exists = self
+            .pcrlock_paths
+            .as_ref()
+            .is_some_and(|p| p.bootloader_measurement("current").exists());
+        if !measurement_exists {
+            log::warn!(
+                "systemd-boot has not been measured. Creating measurement and re-installing..."
+            )
+        };
+
+        if newer_systemd_boot_available || !systemd_boot_is_signed || !measurement_exists {
+            if let Some(pcrlock_paths) = &self.pcrlock_paths {
+                // We do not version the bootloader measurement file. There will only ever be one
+                // bootloader version installed on the ESP and there is no rollback mechanism for it.
+                // That's why we also do not extend the GC roots with the path.
+                //
+                // However, we call this file "next" so that while the new bootloader is installed,
+                // the measurements of the current and next remain available.
+                let bootloader_pcrlock = pcrlock_paths.bootloader_measurement("next");
+                lock_pe(&systemd_boot, &bootloader_pcrlock)
+                    .context("Failed to lock Lanzaboote image with systemd-pcrlock")?;
+            }
+
+            for to in [&self.esp_paths.efi_fallback, &self.esp_paths.systemd_boot] {
+                log::info!("Installing {}", to.display());
+                install_signed(&self.signer, &systemd_boot, to)
                     .with_context(|| format!("Failed to install systemd-boot binary to: {to:?}"))?;
+            }
+
+            // After installing the bootloader, rename the pcrlock measurement from "next" to
+            // "current". So that we can install "next" on the next update again.
+            if let Some(pcrlock_paths) = &self.pcrlock_paths {
+                let next = pcrlock_paths.bootloader_measurement("next");
+                let current = pcrlock_paths.bootloader_measurement("current");
+                log::debug!(
+                    "Renaming {} to {} after installing the bootloader.",
+                    next.display(),
+                    current.display()
+                );
+                fs::rename(&next, &current).with_context(|| {
+                    format!(
+                        "Failed to rename {} to {}",
+                        next.display(),
+                        current.display()
+                    )
+                })?;
             }
         }
 

--- a/rust/tool/systemd/src/main.rs
+++ b/rust/tool/systemd/src/main.rs
@@ -2,6 +2,7 @@ mod architecture;
 mod cli;
 mod esp;
 mod install;
+mod pcrlock;
 mod version;
 
 use clap::Parser;

--- a/rust/tool/systemd/src/pcrlock.rs
+++ b/rust/tool/systemd/src/pcrlock.rs
@@ -1,0 +1,65 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+pub struct PcrlockPaths {
+    /// The directory containing the Lanzaboote `.pclock` config files for systemd-pcrlock.
+    pcrlock: PathBuf,
+    lanzaboote: PathBuf,
+    bootloader: PathBuf,
+}
+
+impl PcrlockPaths {
+    pub fn new(pcrlock: impl AsRef<Path>) -> Self {
+        let pcrlock = pcrlock.as_ref().to_path_buf();
+        Self {
+            pcrlock: pcrlock.clone(),
+            lanzaboote: pcrlock.join("635-lanzaboote.pcrlock.d"),
+            bootloader: pcrlock.join("630-bootloader.pcrlock.d"),
+        }
+    }
+
+    pub fn lanzaboote(&self) -> &Path {
+        &self.lanzaboote
+    }
+
+    /// Return the path to a pcrlock measurement file inside the pcrlock directory for Lanzaboote.
+    pub fn bootloader_measurement(&self, name: impl AsRef<str>) -> PathBuf {
+        self.bootloader.join(format!("{}.pcrlock", name.as_ref()))
+    }
+
+    /// Return the path to a pcrlock measurement file inside the pcrlock directory for Lanzaboote.
+    pub fn lanzaboote_measurement(&self, name: impl AsRef<str>) -> PathBuf {
+        self.lanzaboote.join(format!("{}.pcrlock", name.as_ref()))
+    }
+
+    /// Return all pcrlock paths.
+    ///
+    /// This is useful for including the leading directories in the GC roots.
+    pub fn iter(&self) -> std::array::IntoIter<&PathBuf, 2> {
+        [&self.pcrlock, &self.lanzaboote].into_iter()
+    }
+}
+
+/// Lock a PE binary with systemd-pcrlock and write the pcrlock component.
+///
+/// This calls `systemd-pcrlock lock-pe` and writes the component to `pcrlock_component`.
+pub fn lock_pe(binary_path: impl AsRef<Path>, pcrlock_component: impl AsRef<Path>) -> Result<()> {
+    let status = Command::new("systemd-pcrlock")
+        .arg("lock-pe")
+        .arg(binary_path.as_ref())
+        .arg("--pcrlock")
+        .arg(pcrlock_component.as_ref())
+        .status()
+        .context("Failed to run systemd-pcrlock. Most likely, the binary is not on PATH")?;
+    if !status.success() {
+        bail!(
+            "Failed to lock PE binary {} via systemd-pcrlock and write pcrlock component to {}",
+            binary_path.as_ref().display(),
+            pcrlock_component.as_ref().display()
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds support for Measured Boot via systemd-pcrlock. Uses PCR4 to measure boot artifacts.

Includes support for automatically enrolling and unattended system into a measured boot state.

 Support should still be considered experimental because pcrlock is still experimental and I'm lacking experience with it.