### PR TITLE
fix: don't reinstall systemd-boot when pcrlock is unconfigured

### DIFF
--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -453,17 +453,17 @@ impl<S: Signer> Installer<S> {
             log::warn!("systemd-boot is not signed. Replacing it with a signed binary...")
         };
 
-        let measurement_exists = self
+        let measurement_missing = self
             .pcrlock_paths
             .as_ref()
-            .is_some_and(|p| p.bootloader_measurement("current").exists());
-        if !measurement_exists {
+            .is_some_and(|p| !p.bootloader_measurement("current").exists());
+        if measurement_missing {
             log::warn!(
                 "systemd-boot has not been measured. Creating measurement and re-installing..."
             )
         };
 
-        if newer_systemd_boot_available || !systemd_boot_is_signed || !measurement_exists {
+        if newer_systemd_boot_available || !systemd_boot_is_signed || measurement_missing {
             if let Some(pcrlock_paths) = &self.pcrlock_paths {
                 // We do not version the bootloader measurement file. There will only ever be one
                 // bootloader version installed on the ESP and there is no rollback mechanism for it.


### PR DESCRIPTION
I discovered a flakey test, `keep_systemd_boot_binaries`. This is because of a bug introduced by #564. The `measurement_exists` check was faulty, causing constant overwrites. Inverting the semantics of `measurement_exists` -> `measurement_missing`, fixes this issue due to the nature of `Option::is_some_and`.


The test was flakey because of the assertion being done used mtime(), which has second-level resolution. So the overwrite was only caught sometimes based on timing. For me, this caused really weird behavior, where Lanzaboote would would compile and all checks would pass on one machine, but not another due to the difference in performance, this is especially the case when under load.


Root caused with Claude Opus 4.6 via Oh-My-Pi