### PR TITLE
stub: remove features that depend on Secure Boot status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
   guide](https://nix-community.github.io/lanzaboote/how-to-guides/enable-measured-boot.html)
   to get started using this.
 
+### Removed
+
+- Removed support for features that depended on whether Secure Boot was enabled
+  in the Lanzaboote stub. This was done so that users can leverage Measured
+  Boot without requiring Secure Boot.
+    - Removed support for loading kernels or initrds whose hashes do not match
+      those embedded into the Lanzaboote image.
+
 ## 1.0.0
 
 ### Added

--- a/nix/tests/lanzaboote/hash-mismatch-initrd.nix
+++ b/nix/tests/lanzaboote/hash-mismatch-initrd.nix
@@ -21,6 +21,6 @@
       machine.crash()
 
       machine.start()
-      machine.succeed("bootctl", timeout=120)
+      machine.wait_for_console_text("hash does not match")
     '';
 }

--- a/nix/tests/lanzaboote/hash-mismatch-kernel.nix
+++ b/nix/tests/lanzaboote/hash-mismatch-kernel.nix
@@ -29,6 +29,6 @@
       machine.crash()
 
       machine.start()
-      machine.succeed("bootctl", timeout=120)
+      machine.wait_for_console_text("hash does not match")
     '';
 }

--- a/nix/tests/lanzaboote/measured-boot.nix
+++ b/nix/tests/lanzaboote/measured-boot.nix
@@ -14,10 +14,14 @@
       virtualisation.tpm.enable = true;
 
       lanzabooteTest = {
+        # Don't enroll Secure Boot keys via systemd-boot. We don't need them to
+        # test Measured Boot and this speeds up our boot.
+        keyFixture = lib.mkForce false;
         persistentRoot = true;
       };
 
       boot.lanzaboote = {
+        allowUnsigned = true;
         configurationLimit = 8;
         measuredBoot = {
           enable = true;

--- a/rust/uefi/linux-bootloader/src/measure.rs
+++ b/rust/uefi/linux-bootloader/src/measure.rs
@@ -14,6 +14,7 @@ use uefi::{
     runtime::{self, VariableAttributes},
 };
 
+const TPM_PCR_INDEX_BOOT_LOADER: PcrIndex = PcrIndex(4);
 /// This is where any stub payloads are extended, e.g. kernel ELF image, embedded initrd
 /// and so on.
 /// Compared to PCR4, this contains only the unified sections rather than the whole PE image as-is.
@@ -30,6 +31,11 @@ const TPM_PCR_INDEX_KERNEL_IMAGE: PcrIndex = PcrIndex(11);
 const TPM_PCR_INDEX_KERNEL_CONFIG: PcrIndex = PcrIndex(12);
 /// This is where we extend the initrd sysext images into which we pass to the booted kernel
 const TPM_PCR_INDEX_SYSEXTS: PcrIndex = PcrIndex(13);
+
+/// Measure arbitrary data into PCR 4 via an IPL event.
+pub fn measure_boot_loader(buffer: &[u8], description: &str) -> uefi::Result<()> {
+    tpm_log_event_ascii(TPM_PCR_INDEX_BOOT_LOADER, buffer, description)
+}
 
 pub fn measure_image(
     image: &PeInMemory,

--- a/rust/uefi/linux-bootloader/src/measure.rs
+++ b/rust/uefi/linux-bootloader/src/measure.rs
@@ -80,12 +80,14 @@ pub fn measure_image(
                 TPM_PCR_INDEX_KERNEL_IMAGE,
                 section_name_ascii.as_bytes(),
                 section_name,
-            )? {
+            )
+            .is_ok()
+            {
                 measurements += 1;
             }
 
             // 2. "The (binary) section contents"
-            if tpm_log_event_ascii(TPM_PCR_INDEX_KERNEL_IMAGE, data, section_name)? {
+            if tpm_log_event_ascii(TPM_PCR_INDEX_KERNEL_IMAGE, data, section_name).is_ok() {
                 measurements += 1;
             }
         }
@@ -132,7 +134,9 @@ pub fn measure_companion_initrds(companions: &[CompanionInitrd]) -> uefi::Result
                     TPM_PCR_INDEX_KERNEL_CONFIG,
                     initrd.cpio.as_ref(),
                     "Credentials initrd",
-                )? {
+                )
+                .is_ok()
+                {
                     measurements += 1;
                     credentials_measured += 1;
                 }
@@ -142,7 +146,9 @@ pub fn measure_companion_initrds(companions: &[CompanionInitrd]) -> uefi::Result
                     TPM_PCR_INDEX_KERNEL_CONFIG,
                     initrd.cpio.as_ref(),
                     "Global credentials initrd",
-                )? {
+                )
+                .is_ok()
+                {
                     measurements += 1;
                     credentials_measured += 1;
                 }
@@ -152,7 +158,9 @@ pub fn measure_companion_initrds(companions: &[CompanionInitrd]) -> uefi::Result
                     TPM_PCR_INDEX_SYSEXTS,
                     initrd.cpio.as_ref(),
                     "System extension initrd",
-                )? {
+                )
+                .is_ok()
+                {
                     measurements += 1;
                     sysext_measured = true;
                 }

--- a/rust/uefi/linux-bootloader/src/tpm.rs
+++ b/rust/uefi/linux-bootloader/src/tpm.rs
@@ -38,9 +38,9 @@ pub fn tpm_log_event_ascii(
     pcr_index: PcrIndex,
     buffer: &[u8],
     description: &str,
-) -> uefi::Result<bool> {
+) -> uefi::Result<()> {
     if pcr_index.0 == u32::MAX {
-        return Ok(false);
+        return Err(uefi::Status::UNSUPPORTED.into());
     }
     if let Ok(mut tpm2) = open_capable_tpm2() {
         let description_encoded = description
@@ -54,5 +54,5 @@ pub fn tpm_log_event_ascii(
         tpm2.hash_log_extend_event(Default::default(), buffer, &event)?;
     }
 
-    Ok(true)
+    Ok(())
 }

--- a/rust/uefi/stub/src/common.rs
+++ b/rust/uefi/stub/src/common.rs
@@ -6,6 +6,7 @@ use uefi::{
 };
 
 use linux_bootloader::linux_loader::InitrdLoader;
+use linux_bootloader::measure::measure_boot_loader;
 use linux_bootloader::pe_loader::Image;
 use linux_bootloader::pe_section::pe_section_as_string;
 
@@ -20,28 +21,46 @@ pub fn extract_string(pe_data: &[u8], section: &str) -> uefi::Result<CString16> 
 ///
 /// If Secure Boot is active, this is always the embedded one (since the one passed from the bootloader may come from a malicious type 1 entry).
 /// If Secure Boot is not active, the command line passed from the bootloader is used, falling back to the embedded one.
-pub fn get_cmdline(embedded: &CStr16, secure_boot_enabled: bool) -> Vec<u8> {
-    if secure_boot_enabled {
-        // The command line passed from the bootloader cannot be trusted, so it is not used when Secure Boot is active.
-        embedded.as_bytes().to_vec()
-    } else {
-        let passed = boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())
-            .map(|loaded_image| loaded_image.load_options_as_bytes().map(|b| b.to_vec()));
-        match passed {
-            Ok(Some(passed)) => passed,
-            // If anything went wrong, fall back to the embedded command line.
-            _ => embedded.as_bytes().to_vec(),
+///
+/// If we read a user provided cmdline, we measure it into PCR4 to invalidate the PCR. This way we
+/// can support Measured Boot without Secure Boot while still giving users the option to edit the
+/// kernel cmdline on the fly for debugging.
+pub fn get_cmdline(embedded: &CStr16) -> Vec<u8> {
+    let secure_boot_enabled = get_secure_boot_status();
+    if !secure_boot_enabled {
+        let load_options = get_load_options();
+        if let Some(passed) = load_options {
+            // The passed cmdline is allowed to be the same as the embedded one without needing to
+            // be measured.
+            if passed == embedded.as_bytes() {
+                return passed;
+            }
+            // Measuring is mandatory here. If the measurement fails, return the embedded cmdline.
+            if measure_boot_loader(&passed, "Custom user provided kernel cmdline").is_ok() {
+                return passed;
+            }
         }
     }
+    embedded.as_bytes().to_vec()
 }
 
-/// Check whether Secure Boot is active, and we should be enforcing integrity checks.
+/// Obtain the load options of the currently loaded image.
+///
+/// This is used for example to pass a customer user provided kernel cmdline from the boot loader
+/// to the booted image.
+fn get_load_options() -> Option<Vec<u8>> {
+    boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())
+        .ok()
+        .and_then(|loaded_image| loaded_image.load_options_as_bytes().map(|b| b.to_vec()))
+}
+
+// Check whether Secure Boot is active.
 ///
 /// In case of doubt, true is returned to be on the safe side.
 pub fn get_secure_boot_status() -> bool {
     // The firmware initialized SecureBoot to 1 if performing signature checks, and 0 if it doesn't.
     // Applications are not supposed to modify this variable (in particular, don't change the value from 1 to 0).
-    let secure_boot_enabled = runtime::get_variable(
+    runtime::get_variable(
         cstr16!("SecureBoot"),
         &VariableVendor(guid!("8be4df61-93ca-11d2-aa0d-00e098032b8c")),
         &mut [1],
@@ -64,13 +83,7 @@ pub fn get_secure_boot_status() -> bool {
             warn!("Failed to read SecureBoot variable: {err}. Performing verification anyway.");
             true
         }
-    });
-
-    if !secure_boot_enabled {
-        warn!("Secure Boot is not active!");
-    }
-
-    secure_boot_enabled
+    })
 }
 
 /// Boot the Linux kernel without checking the PE signature.

--- a/rust/uefi/stub/src/thin.rs
+++ b/rust/uefi/stub/src/thin.rs
@@ -58,8 +58,12 @@ impl UkiComponents {
             .expect("Failed to read initrd file into memory");
 
         let secure_boot_enabled = get_secure_boot_status();
-        check_hash(&kernel_data, kernel_hash, "Kernel", secure_boot_enabled)?;
-        check_hash(&initrd_data, initrd_hash, "Initrd", secure_boot_enabled)?;
+        if !secure_boot_enabled {
+            warn!("Secure Boot is not active!");
+        }
+
+        check_hash(&kernel_data, kernel_hash, "Kernel")?;
+        check_hash(&initrd_data, initrd_hash, "Initrd")?;
 
         Ok(Self {
             kernel_data,
@@ -71,18 +75,12 @@ impl UkiComponents {
 
 /// Verify some data against its expected hash.
 ///
-/// In case of a mismatch:
-/// * If Secure Boot is active, an error message is logged, and the SECURITY_VIOLATION error is returned to stop the boot.
-/// * If Secure Boot is not active, only a warning is logged, and the boot process is allowed to continue.
-fn check_hash(data: &[u8], expected_hash: Hash, name: &str, secure_boot: bool) -> uefi::Result<()> {
+/// In case of a mismatch a SECURITY_VIOLATION error is returned and the boot is stopped.
+fn check_hash(data: &[u8], expected_hash: Hash, name: &str) -> uefi::Result<()> {
     let hash_correct = Sha256::digest(data) == expected_hash;
     if !hash_correct {
-        if secure_boot {
-            error!("{name} hash does not match!");
-            return Err(Status::SECURITY_VIOLATION.into());
-        } else {
-            warn!("{name} hash does not match! Continuing anyway.");
-        }
+        error!("{name} hash does not match!");
+        return Err(Status::SECURITY_VIOLATION.into());
     }
     Ok(())
 }
@@ -92,8 +90,7 @@ pub fn boot_linux(
     components: UkiComponents,
     dynamic_initrds: Vec<Vec<u8>>,
 ) -> uefi::Result<()> {
-    let secure_boot_enabled = get_secure_boot_status();
-    let cmdline = get_cmdline(&components.cmdline, secure_boot_enabled);
+    let cmdline = get_cmdline(&components.cmdline);
 
     let mut initrd_data = components.initrd_data;
 


### PR DESCRIPTION
This is done in preparation for running Measured Boot without Secure Boot.

Because we measure only the stub into PCR4, we expect that the stub correctly verifies the embedded hashes for the kernel and initrd. Until now, however, the stub would only do this if Secure Boot was enabled.