### PR TITLE
treewide: update goblin to 0.10

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,8 +11,5 @@
   "dependencyDashboard": true,
   "nix": {
     "enabled": true
-  },
-  "ignoreDeps": [
-    "goblin"
-  ]
+  }
 }

--- a/rust/tool/Cargo.toml
+++ b/rust/tool/Cargo.toml
@@ -21,6 +21,7 @@ log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 tempfile = { version = "3.23", default-features = false }
+goblin = { version = "0.10" }
 
 [profile.release]
 opt-level = "s"

--- a/rust/tool/shared/Cargo.toml
+++ b/rust/tool/shared/Cargo.toml
@@ -16,7 +16,7 @@ bootspec = "2"
 # Keep the fastrand version aligned with the one from tempfile to avoid two
 # different versions.
 fastrand = "2.3.0"
-goblin = "0.10"
+goblin.workspace = true
 serde = { version = "1.0.228", features = ["derive"] }
 time = "0.3"
 walkdir = "2"

--- a/rust/tool/systemd/Cargo.toml
+++ b/rust/tool/systemd/Cargo.toml
@@ -25,6 +25,6 @@ stderrlog = "0.6.0"
 assert_cmd = "2.1.1"
 expect-test = "1.5.1"
 filetime = "0.2.26"
-goblin = "0.10.3"
+goblin.workspace = true
 rand = "0.10.0"
 walkdir = "2.5.0"

--- a/rust/uefi/Cargo.lock
+++ b/rust/uefi/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+checksum = "983a6aafb3b12d4c41ea78d39e189af4298ce747353945ff5105b54a056e5cd9"
 dependencies = [
  "log",
  "plain",
@@ -185,18 +185,18 @@ dependencies = [
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/uefi/linux-bootloader/Cargo.toml
+++ b/rust/uefi/linux-bootloader/Cargo.toml
@@ -18,8 +18,7 @@ log = { workspace = true, features = [ "max_level_info", "release_max_level_warn
 uefi = { workspace = true, default-features = false, features = [ "alloc", "global_allocator" ] }
 
 bitflags = "2.10.0"
-# Update blocked by #237
-goblin = { version = "=0.6.1", default-features = false, features = [ "pe64", "alloc" ]}
+goblin = { version = "0.10", default-features = false, features = [ "pe64", "alloc" ]}
 
 pio = { path = "../pio" }
 

--- a/rust/uefi/linux-bootloader/src/measure.rs
+++ b/rust/uefi/linux-bootloader/src/measure.rs
@@ -48,7 +48,12 @@ pub fn measure_image(
     // might conceivably change while we look at the slice.
     // (data sections := all unified sections that can be measured.)
     let pe_binary = unsafe { image.as_slice() };
-    let pe = goblin::pe::PE::parse(pe_binary).map_err(|_err| uefi::Status::LOAD_ERROR)?;
+
+    let mut parse_options = goblin::pe::options::ParseOptions::default();
+    // Don't parse the certificates because they are not present in the in-memory representation.
+    parse_options.parse_attribute_certificates = false;
+    let pe = goblin::pe::PE::parse_with_opts(pe_binary, &parse_options)
+        .map_err(|_err| uefi::Status::LOAD_ERROR)?;
 
     // Build a list of (unified_section, pe_section) pairs and sort by canonical order.
     // Per UKI spec: "shall measure the sections listed above, starting from the .linux section,

--- a/rust/uefi/linux-bootloader/src/pe_loader.rs
+++ b/rust/uefi/linux-bootloader/src/pe_loader.rs
@@ -137,8 +137,7 @@ impl Image {
         if pe
             .header
             .optional_header
-            .and_then(|h| *h.data_directories.get_base_relocation_table())
-            .is_some()
+            .is_some_and(|h| h.data_directories.get_base_relocation_table().is_some())
         {
             return Err(Status::INCOMPATIBLE_VERSION.into());
         }
@@ -148,12 +147,16 @@ impl Image {
         // Platform-specific flushes need to be performed to prevent this from happening.
         make_instruction_cache_coherent(image);
 
-        if pe.entry >= image.len() {
+        let pe_entry: usize = pe
+            .entry
+            .try_into()
+            .expect("Failed to convert RVA of PE binary to usize");
+        if pe_entry >= image.len() {
             return Err(Status::LOAD_ERROR.into());
         }
         let entry = unsafe {
             core::mem::transmute::<&u8, extern "efiapi" fn(Handle, Option<NonNull<c_void>>) -> Status>(
-                &image[pe.entry],
+                &image[pe_entry],
             )
         };
 

--- a/rust/uefi/linux-bootloader/src/pe_section.rs
+++ b/rust/uefi/linux-bootloader/src/pe_section.rs
@@ -6,7 +6,7 @@
 
 use alloc::{borrow::ToOwned, string::String, vec::Vec};
 use core::cmp::min;
-use goblin::pe::section_table::SectionTable;
+use goblin::pe::{options::ParseOptions, section_table::SectionTable};
 
 /// Extracts the data of a section in a loaded PE file
 /// based on the section table.
@@ -28,7 +28,10 @@ pub fn pe_section_data<'a>(pe_data: &'a [u8], section: &SectionTable) -> Option<
 /// Extracts the data of a section of a loaded PE file
 /// based on the section name.
 pub fn pe_section<'a>(pe_data: &'a [u8], section_name: &str) -> Option<Vec<u8>> {
-    let pe_binary = goblin::pe::PE::parse(pe_data).ok()?;
+    let mut parse_options = ParseOptions::default();
+    // Don't parse the certificates because they are not present in the in-memory representation.
+    parse_options.parse_attribute_certificates = false;
+    let pe_binary = goblin::pe::PE::parse_with_opts(pe_data, &parse_options).ok()?;
 
     pe_binary
         .sections


### PR DESCRIPTION
Fixes #237 