### PR TITLE
docs: generalize troubleshooting case when make-policy fails

### DIFF
--- a/docs/explanation/troubleshooting.md
+++ b/docs/explanation/troubleshooting.md
@@ -84,10 +84,11 @@ In this case you can convert in place while the partition is not in use with `cr
 
 ## PCR policy error when running `nixos-rebuild`
 
-In some cases, `nixos-rebuild` fails due to PCR policy violations while trying to add more entries in `boot.lanzaboote.measuredBoot.pcrs`.
-This error message has been observed before:
+In some cases, `nixos-rebuild` fails due to PCR policy violations (e.g., when trying to add more entries in `boot.lanzaboote.measuredBoot.pcrs`).
+These error messages have been observed before:
 ```
 Failed to submit PCR policy to TPM: Remote address changed
+Failed to submit AuthorizeNV policy: Remote address changed
 ```
 
 Remove `/var/lib/systemd/pcrlock.json` and run nixos-rebuild to re-initialize the `pcrlock.json`.


### PR DESCRIPTION
After updating the firmware on my Framework 13, the `systemd-pcrlock make-policy` command in `nixos-rebuild switch` failed with `Failed to submit AuthorizeNV policy: Remote address changed`. I could not find helpful information searching for the error message and only eventually discovered a helpful case in the troubleshooting section of the docs.

The described steps solved my problem, but the error message I saw was different from the message in the docs, and I did not modify the `pcrs` option as mentioned in the issue. I suggest to generalize the problem description to all make-policy failures (keeping the existing case as an example) and add the error message I saw, so that hopefully a search engine could also find and suggest the troubleshooting page when searching for the specific message.