### PR TITLE
module: add pcrlock-secureboot overrides only when measuredBoot is enabled

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -484,12 +484,16 @@ in
     # create these measurements after we have booted in a Secure Boot system
     # for the first time. Thus, run this only if Secure Boot is already enabled
     # if we autoEnrollKeys.
-    systemd.services.systemd-pcrlock-secureboot-policy = lib.mkIf cfg.autoEnrollKeys.enable {
-      unitConfig.ConditionSecurity = "uefi-secureboot";
-    };
-    systemd.services.systemd-pcrlock-secureboot-authority = lib.mkIf cfg.autoEnrollKeys.enable {
-      unitConfig.ConditionSecurity = "uefi-secureboot";
-    };
+    systemd.services.systemd-pcrlock-secureboot-policy =
+      lib.mkIf (cfg.measuredBoot.enable && cfg.autoEnrollKeys.enable)
+        {
+          unitConfig.ConditionSecurity = "uefi-secureboot";
+        };
+    systemd.services.systemd-pcrlock-secureboot-authority =
+      lib.mkIf (cfg.measuredBoot.enable && cfg.autoEnrollKeys.enable)
+        {
+          unitConfig.ConditionSecurity = "uefi-secureboot";
+        };
 
     systemd.services.systemd-pcrlock-make-policy = lib.mkIf cfg.measuredBoot.enable {
       wantedBy = [ "sysinit.target" ];


### PR DESCRIPTION
The upstream `systemd-pcrlock-secureboot-{policy,authority}` units are only added to `additionalUpstreamSystemUnits` when `measuredBoot.enable` is set, but the `ConditionSecurity` overrides on those units were added when `autoEnrollKeys` is enabled without checking for `measuredBoot`. With `autoEnrollKeys=true` and `measuredBoot=false` NixOS therefore creates a fresh unit containing just `ConditionSecurity`, and no `ExecStart`, which systemd refuses to load:

```
systemd-pcrlock-secureboot-authority.service: Service has no ExecStart=, ExecStop=, or SuccessAction=. Refusing.
```
