### PR TITLE
module: don't set bootspec.enable

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -439,7 +439,6 @@ in
     ];
 
     boot.bootspec = {
-      enable = true;
       extensions."org.nix-community.lanzaboote" = {
         sort_key = config.boot.lanzaboote.sortKey;
       };


### PR DESCRIPTION
It's default on all relevant NixOS versions and was just removed from unstable earlier today.