### PR TITLE
docs: add note about persisting /var/lib/auto-cryptenroll on impermanent systems

### DIFF
--- a/docs/how-to-guides/automatically-enroll-keys.md
+++ b/docs/how-to-guides/automatically-enroll-keys.md
@@ -8,6 +8,9 @@ boot.lanzaboote.autoEnrollKeys = {
 };
 ```
 
+> [!NOTE]
+> If you're using an ephemeral root, you need to persist `/var/lib/auto-cryptenroll` across reboots.
+
 By default, when you enable auto enrollment, you will enroll the Microsoft keys
 alongside your own keys. If you don't know much about Secure Boot, you should
 stick with this default. Some Option ROMs are signed with the Microsoft keys


### PR DESCRIPTION
## Summary

`/var/lib/auto-cryptenroll` needs to be persisted otherwise lanzaboote will try to reenroll the keys on every configuration switch

These changes are documentation-only and do not affect functionality.
