### PR TITLE
tool: make Measured Boot policy cover PCR4 throughout bootloader update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## unreleased
+
+### Changed
+
+- The Measured Boot integration now supports locking against PCR4 throughout a
+  bootloader update. Previously a bootloader update was not covered by the
+  generated TPM policies and caused PCR4 to be dropped from the policy.
+  Users are expected to reboot between two consecutive bootloader updates.
+  Because of an implementational limitation in systemd-pcrlock[1], this change
+  reduces the maximum number of NixOS generations one can use with this
+  Measured Boot integration from `8` to `4`.
+
+[1]: https://github.com/systemd/systemd/issues/41526
+
 ## 1.1.0
 
 ### Added

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -429,13 +429,13 @@ in
         '';
       }
       {
-        assertion = cfg.measuredBoot.enable -> (configurationLimit > 0 && configurationLimit <= 8);
+        assertion = cfg.measuredBoot.enable -> (configurationLimit > 0 && configurationLimit <= 4);
         message = ''
-          If Measured Boot is enabled, you cannot store more than 8 generations on the ESP.
+          If Measured Boot is enabled, you cannot store more than 4 generations on the ESP.
 
-            This is a strict limit required and enforced by systemd-pcrlock.
+            This is a strict limit introduced and enforced by systemd-pcrlock.
 
-            Set `boot.lanzaboote.configurationLimit = 8;` to reduce the number of generations you store.
+            Set `boot.lanzaboote.configurationLimit = 4;` to reduce the number of generations you store.
         '';
       }
     ];

--- a/nix/tests/lanzaboote/auto-reboot.nix
+++ b/nix/tests/lanzaboote/auto-reboot.nix
@@ -32,7 +32,7 @@ in
         };
 
         # Measured Boot
-        configurationLimit = 8;
+        configurationLimit = 4;
         measuredBoot = {
           enable = true;
           pcrs = [

--- a/nix/tests/lanzaboote/measured-boot.nix
+++ b/nix/tests/lanzaboote/measured-boot.nix
@@ -22,7 +22,7 @@
 
       boot.lanzaboote = {
         allowUnsigned = true;
-        configurationLimit = 8;
+        configurationLimit = 4;
         measuredBoot = {
           enable = true;
           pcrs = [

--- a/rust/tool/systemd/src/install.rs
+++ b/rust/tool/systemd/src/install.rs
@@ -466,41 +466,43 @@ impl<S: Signer> Installer<S> {
         };
 
         if newer_systemd_boot_available || !systemd_boot_is_signed || !measurement_exists {
+            // The following assumes that the "current" measurement before an update
+            // always refers to the bootloader that was used for startup of the system
+            // that performs the bootloader update.
+            // This means that a reboot must happen between two consecutive bootloader
+            // updates, otherwise we cannot produce a policy that covers PCR4 with this
+            // approach.
             if let Some(pcrlock_paths) = &self.pcrlock_paths {
-                // We do not version the bootloader measurement file. There will only ever be one
-                // bootloader version installed on the ESP and there is no rollback mechanism for it.
-                // That's why we also do not extend the GC roots with the path.
-                //
-                // However, we call this file "next" so that while the new bootloader is installed,
-                // the measurements of the current and next remain available.
-                let bootloader_pcrlock = pcrlock_paths.bootloader_measurement("next");
-                lock_pe(&systemd_boot, &bootloader_pcrlock)
-                    .context("Failed to lock Lanzaboote image with systemd-pcrlock")?;
+                // Path to measurement that was used prior to this implementation
+                let legacy_path = pcrlock_paths.bootloader_measurement("next");
+                // Path to measurement of the loader PE that will be overridden by a new one
+                let previous = if legacy_path.exists() {
+                    legacy_path
+                } else {
+                    pcrlock_paths.bootloader_measurement("previous")
+                };
+                // Path to measurement of the new loader PE that will override the current one
+                let current = pcrlock_paths.bootloader_measurement("current");
+
+                if current.exists() {
+                    fs::rename(&current, &previous).with_context(|| {
+                        format!(
+                            "Failed to rename {} to {}",
+                            current.display(),
+                            previous.display()
+                        )
+                    })?;
+                }
+
+                // Measure the bootloader we are about to install as "current".
+                lock_pe(&systemd_boot, &current)
+                    .context("Failed to lock systemd-boot image with systemd-pcrlock")?;
             }
 
             for to in [&self.esp_paths.efi_fallback, &self.esp_paths.systemd_boot] {
                 log::info!("Installing {}", to.display());
                 install_signed(&self.signer, &systemd_boot, to)
                     .with_context(|| format!("Failed to install systemd-boot binary to: {to:?}"))?;
-            }
-
-            // After installing the bootloader, rename the pcrlock measurement from "next" to
-            // "current". So that we can install "next" on the next update again.
-            if let Some(pcrlock_paths) = &self.pcrlock_paths {
-                let next = pcrlock_paths.bootloader_measurement("next");
-                let current = pcrlock_paths.bootloader_measurement("current");
-                log::debug!(
-                    "Renaming {} to {} after installing the bootloader.",
-                    next.display(),
-                    current.display()
-                );
-                fs::rename(&next, &current).with_context(|| {
-                    format!(
-                        "Failed to rename {} to {}",
-                        next.display(),
-                        current.display()
-                    )
-                })?;
             }
         }
 


### PR DESCRIPTION
Relates to #614 

Before this change, a bootloader update would cause PCR4 to no longer be part of the generated pcrlock policy because there only was a component file (aka. measurement) for the freshly installed, but not yet booted bootloader, so the policy generated from the components could not match the PCR4 state of the TPM.

This meant that the policy was much less strict between this bootloader update and the next rebuild *after* a reboot that includes the new bootloader, therby undermining the main goal that the Measured Boot integration tries to achieve.

Now, the component file for the bootloader from before the update is kept so that that the policy continues to cover PCR4. It is important for users to reboot between two bootloader updates, otherwise the issue above arises again. Unfortunately that case cannot be easily addressed without much more involved logic in lanzaboote.

A downside from this is that the maximum number of NixOS generations is further reduced from 8 to 4, because we now always have two variants for the bootloader. This is nothing lanzaboote can work around in any meaningful way, instead this needs to be addressed in systemd. See the upstream issue: https://github.com/systemd/systemd/issues/41526