### PR TITLE
Added fwupd patch to deal with efi_app_location

### DIFF
--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -625,8 +625,12 @@ in
     };
 
     systemd.services.fwupd = lib.mkIf config.services.fwupd.enable {
-      # Tell fwupd to load its efi files from /run
-      environment.FWUPD_EFIAPPDIR = "/run/fwupd-efi";
+      # Patch fwupd with /run/fwupd-efi location
+      package = pkgs.fwupd.overrideAttrs (old: {
+        mesonFlags = map (
+          flag: if lib.hasPrefix "-Defi_app_location=" flag then "-Defi_app_location=/run/fwupd-efi" else flag
+        ) old.mesonFlags;
+      });
     };
 
     systemd.services.fwupd-efi = lib.mkIf config.services.fwupd.enable {

--- a/nix/modules/lanzaboote.nix
+++ b/nix/modules/lanzaboote.nix
@@ -624,14 +624,14 @@ in
       };
     };
 
-    systemd.services.fwupd = lib.mkIf config.services.fwupd.enable {
-      # Patch fwupd with /run/fwupd-efi location
-      package = pkgs.fwupd.overrideAttrs (old: {
+    # Patch fwupd with /run/fwupd-efi location
+    services.fwupd.package = lib.mkIf config.services.fwupd.enable (
+      pkgs.fwupd.overrideAttrs (old: {
         mesonFlags = map (
           flag: if lib.hasPrefix "-Defi_app_location=" flag then "-Defi_app_location=/run/fwupd-efi" else flag
         ) old.mesonFlags;
-      });
-    };
+      })
+    );
 
     systemd.services.fwupd-efi = lib.mkIf config.services.fwupd.enable {
       description = "Sign fwupd EFI app";


### PR DESCRIPTION
I'm not sure what the progress is at with https://github.com/nix-community/lanzaboote/issues/591 but I wanted to fix it on my system (where I've tested this patch and it worked using `nixpkgs-unstable` rev 61b7c44c4073f0b827768aff0049561b5110ea5a). 